### PR TITLE
(PIE-292) Add Custom Report processor

### DIFF
--- a/lib/puppet/reports/servicenow.rb
+++ b/lib/puppet/reports/servicenow.rb
@@ -1,9 +1,42 @@
-require 'puppet'
+require 'puppet/util/servicenow'
 
 Puppet::Reports.register_report(:servicenow) do
-  desc 'TODO: Fill this in'
+  desc 'Create Servicenow incidents from Puppet reports'
+
+  include Puppet::Util::Servicenow
 
   def process
-    raise 'TODO: Fill this in'
+    unless status != 'unchanged' || noop_pending
+      # do not create an incident
+      return false
+    end
+    settings_hash = settings
+    short_description_status = (status == 'unchanged') ? 'pending changes' : status
+    incident_data = {
+      short_description: "Puppet run report #{time} (status: #{short_description_status}) for node #{host}",
+      description: "See [code]<a class='web' target='_blank' href='https://#{settings_hash['pe_console']}/#/inspect/report/#{job_id}/metrics'>Report</a>[/code] for more details",
+      caller: settings_hash['caller'],
+      category: settings_hash['category'],
+      contact_type: settings_hash['contact_type'],
+      state: settings_hash['state'],
+      impact: settings_hash['impact'],
+      urgency: settings_hash['urgency'],
+      assignment_group: settings_hash['assignment_group'],
+      assigned_to: settings_hash['assigned_to'],
+    }
+
+    endpoint = "https://#{settings_hash['snow_instance']}/api/now/table/incident"
+
+    response = do_snow_request(endpoint,
+                               'Post',
+                               incident_data,
+                               settings_hash['user'],
+                               settings_hash['password'],
+                               settings_hash['oauth_token'])
+
+    raise "Incident creation failed. Error from #{endpoint} (status: #{reponse.code}): #{response.body}" if reponse.code.to_i >= 400
+    return true
+  rescue StandardError => e
+    Puppet.err "Could not send incident to Servicenow: #{e}\n#{e.backtrace}"
   end
 end

--- a/lib/puppet/util/servicenow.rb
+++ b/lib/puppet/util/servicenow.rb
@@ -1,0 +1,42 @@
+require 'puppet'
+require 'puppet/util'
+require 'fileutils'
+require 'yaml'
+require 'json'
+require 'net/http'
+require 'openssl'
+require 'base64'
+
+# servicenow.rb
+module Puppet::Util::Servicenow
+  def settings
+    settings_file = Puppet[:confdir] + '/servicenow.yaml'
+    YAML.load_file(settings_file)
+  end
+  module_function :settings
+
+  def do_snow_request(uri, http_verb, body, user = nil, password = nil, oauth_token = nil)
+    uri = URI.parse(uri)
+
+    Net::HTTP.start(uri.host,
+                    uri.port,
+                    use_ssl: uri.scheme == 'https',
+                    verify_mode: OpenSSL::SSL::VERIFY_NONE) do |http|
+      header = { 'Content-Type' => 'application/json' }
+      # Interpolate the HTTP verb and constantize to a class name.
+      request_class_string = "Net::HTTP::#{http_verb.capitalize}"
+      request_class = Object.const_get(request_class_string)
+      # Add uri, fields and authentication to request
+      request = request_class.new("#{uri.path}?#{uri.query}", header)
+      request.body = body.to_json
+      if oauth_token
+        request['Authorization'] = "Bearer #{oauth_token}"
+      else
+        request.basic_auth(user, password)
+      end
+      # Make request to ServiceNow and return response
+      http.request(request)
+    end
+  end
+  module_function :do_snow_request
+end

--- a/spec/unit/reports/servicenow_spec.rb
+++ b/spec/unit/reports/servicenow_spec.rb
@@ -1,0 +1,84 @@
+require 'spec_helper'
+
+require 'puppet/reports'
+
+servicenow = Puppet::Reports.report(:servicenow)
+
+describe servicenow do
+  let(:processor) do
+    processor = Puppet::Transaction::Report.new('apply')
+    processor.extend(Puppet::Reports.report(:servicenow))
+    processor
+  end
+
+  let(:settings_hash) do
+    { 'pe_console'       => 'test_console',
+      'caller'           => 'test_caller',
+      'category'         => '1',
+      'contact_type'     => '1',
+      'state'            => '1',
+      'impact'           => '1',
+      'urgency'          => '1',
+      'assignment_group' => '1',
+      'assigned_to'      => '1',
+      'snow_instance'    => 'fake.service-now.com',
+      'user'             => 'test_user',
+      'password'         => 'test_password',
+      'oauth_token'      => 'test_token' }
+  end
+
+  context 'with report status: unchanged' do
+    context 'and noop_pending: false' do
+      it 'does nothing' do
+        allow(processor).to receive(:status).and_return 'unchanged'
+        allow(processor).to receive(:noop_pending).and_return false
+
+        results = processor.process
+        # If the report processor returns false we know that the process
+        # method was exited early.
+        expect(results).to be false
+        expect(processor).not_to receive(:do_snow_request)
+      end
+    end
+
+    context 'and noop_pending: true' do
+      it 'creates incident' do
+        allow(processor).to receive(:status).and_return 'unchanged'
+        allow(processor).to receive(:noop_pending).and_return true
+        allow(processor).to receive(:time).and_return '00:00:00'
+        allow(processor).to receive(:host).and_return 'host'
+        allow(processor).to receive(:job_id).and_return '1'
+        allow(processor).to receive(:settings).and_return(settings_hash)
+        # do_snow_request will only be called to create an incident
+        expect(processor).to receive(:do_snow_request)
+        processor.process
+      end
+    end
+  end
+
+  context 'with report status: changed' do
+    it 'creates incident' do
+      allow(processor).to receive(:status).and_return 'changed'
+      allow(processor).to receive(:time).and_return '00:00:00'
+      allow(processor).to receive(:host).and_return 'host'
+      allow(processor).to receive(:job_id).and_return '1'
+      allow(processor).to receive(:settings).and_return(settings_hash)
+      # do_snow_request will only be called to create an incident
+      expect(processor).to receive(:do_snow_request)
+      processor.process
+    end
+  end
+
+  context 'with report status: failed' do
+    it 'creates incident' do
+      allow(processor).to receive(:status).and_return 'failed'
+      allow(processor).to receive(:time).and_return '00:00:00'
+      allow(processor).to receive(:host).and_return 'host'
+      allow(processor).to receive(:job_id).and_return '1'
+      allow(processor).to receive(:settings).and_return(settings_hash)
+      # do_snow_request will only be called to create an incident
+      expect(processor).to receive(:do_snow_request)
+      processor.process
+    end
+  end
+end


### PR DESCRIPTION
This adds a basic custom report processor that sends puppet report data
to servicenow as an incident for reports that included changes or
failed.