### PR TITLE
MAINT-Add_unit_test_for_snow_api_response_codes

### DIFF
--- a/lib/puppet/reports/servicenow.rb
+++ b/lib/puppet/reports/servicenow.rb
@@ -34,7 +34,7 @@ Puppet::Reports.register_report(:servicenow) do
                                password: settings_hash['password'],
                                oauth_token: settings_hash['oauth_token'])
 
-    raise "Incident creation failed. Error from #{endpoint} (status: #{response.code}): #{response.body}" if response.code.to_i >= 400
+    raise "Incident creation failed. Error from #{endpoint} (status: #{response.code}): #{response.body}" if response.code.to_i >= 300
     return true
   rescue StandardError => e
     Puppet.err "Could not send incident to Servicenow: #{e}\n#{e.backtrace}"

--- a/spec/unit/reports/servicenow_spec.rb
+++ b/spec/unit/reports/servicenow_spec.rb
@@ -88,6 +88,20 @@ describe 'ServiceNow report processor' do
     end
   end
 
+  context 'receiving response code greater than 200' do
+    it 'returns the response code from Servicenow' do
+      allow(processor).to receive(:status).and_return 'changed'
+      allow(processor).to receive(:time).and_return '00:00:00'
+      allow(processor).to receive(:host).and_return 'host'
+      allow(processor).to receive(:job_id).and_return '1'
+
+      [300, 400, 500].each do |response_code|
+        allow(processor).to receive(:do_snow_request).and_return(new_mock_response(response_code, { 'sys_id' => 'foo_sys_id' }.to_json))
+        expect { processor.process }.to raise_error(RuntimeError, %r{(status: #{response_code})})
+      end
+    end
+  end
+
   context 'loading ServiceNow config' do
     shared_context 'setup hiera-eyaml' do
       before(:each) do


### PR DESCRIPTION
Unit test to confirm that the report processor will return an error with
the response code returned from Servicenow if that response code is
greater than or equal to 300.