### PR TITLE
(MAINT) Remove branch path on shared libraries

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,4 +1,4 @@
-@Library('puppet_jenkins_shared_libraries@add-ruby-helper-vars') _
+@Library('puppet_jenkins_shared_libraries') _
 
 pipeline{
     agent {


### PR DESCRIPTION
The PR that added the functions we are using has been merged. A branch
path on the import statement in the Jenkins file is no longer required.