### PR TITLE
(PIE-302) Add initial acceptance tests

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -17,3 +17,4 @@ fixtures:
     facts: 'git://github.com/puppetlabs/puppetlabs-facts.git'
     puppet_agent: 'git://github.com/puppetlabs/puppetlabs-puppet_agent.git'
     provision: 'git://github.com/puppetlabs/provision.git'
+    servicenow_tasks: 'git://github.com/puppetlabs/servicenow_tasks.git'

--- a/lib/puppet/reports/servicenow.rb
+++ b/lib/puppet/reports/servicenow.rb
@@ -25,7 +25,7 @@ Puppet::Reports.register_report(:servicenow) do
       assigned_to: settings_hash['assigned_to'],
     }
 
-    endpoint = "https://#{settings_hash['snow_instance']}/api/now/table/incident"
+    endpoint = "https://#{settings_hash['instance']}/api/now/table/incident"
 
     response = do_snow_request(endpoint,
                                'Post',

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -31,34 +31,15 @@ class servicenow_reporting_integration (
     }
   ])
 
-  # Calculate $reports_setting. Idea here is that if the user already included
-  # the 'servicenow' report processor, we return the setting as-is. Otherwise,
-  # we return the setting _with_ the report processor included.
-  #
-  # Note: much of this code was inspired by https://github.com/puppetlabs/puppet/blob/6.16.0/lib/puppet/transaction/report.rb.
-  # Also we use inline_template because $settings::reports != Puppet[:reports] and we want Puppet[:reports] since that's
-  # what the report processor code (transaction/report.rb) uses.
-  $raw_reports_setting = inline_template('<%= Puppet[:reports] %>')
-  if $raw_reports_setting == 'none' {
-    $reports_setting = 'servicenow'
-  } else {
-    $reports = split(regsubst($raw_reports_setting, /(^\s+)|(\s+$)/, '', 'G'), /\s*,\s*/)
-    if 'servicenow' in $reports {
-      # Use the raw setting so that Puppet won't mark it as changed
-      $reports_setting = $raw_reports_setting
-    } else {
-      $reports_setting = join($reports + ['servicenow'], ', ')
-    }
-  }
-
   # Update the reports setting in puppet.conf
-  ini_setting { 'puppetserver puppetconf add servicenow report processor':
-    ensure  => present,
-    path    => "${puppet_base}/puppet.conf",
-    setting => 'reports',
-    value   => $reports_setting,
-    section => 'master',
-    notify  => Service['pe-puppetserver'],
-    require => $resource_dependencies,
+  ini_subsetting { 'puppetserver puppetconf add servicenow report processor':
+    ensure               => present,
+    path                 => "${puppet_base}/puppet.conf",
+    section              => 'master',
+    setting              => 'reports',
+    subsetting           => 'servicenow',
+    subsetting_separator => ',',
+    notify               => Service['pe-puppetserver'],
+    require              => $resource_dependencies,
   }
 }

--- a/spec/acceptance/reporting_spec.rb
+++ b/spec/acceptance/reporting_spec.rb
@@ -1,0 +1,138 @@
+require 'spec_helper_acceptance'
+
+describe 'ServiceNow reporting' do
+  let(:params) do
+    servicenow_config = servicenow_instance.bolt_config['remote']
+
+    {
+      instance: servicenow_instance.uri,
+      user: servicenow_config['user'],
+      password: servicenow_config['password'],
+    }
+  end
+  let(:setup_manifest) do
+    to_manifest(declare('Service', 'pe-puppetserver'), declare('class', 'servicenow_reporting_integration', params))
+  end
+  let(:sitepp_content) do
+    # This is test-specific
+    ''
+  end
+
+  before(:all) do
+    # Some of the tests require an 'unchanged' Puppet run so they use an 'unchanged' site.pp manifest
+    # to simulate this scenario. However, our 'unchanged' Puppet run will still include the default
+    # PE classes _on top_ of our site.pp manifest. Some of these classes trigger changes whenever we
+    # update the reporting module for the tests. To prevent those changes from happening _while_ running
+    # the tests, we do a quick Puppet run _before_ all the tests to enact the PE module-specific changes.
+    # This way, all of our tests begin with a 'clean' Puppet slate.
+    trigger_puppet_run(master)
+  end
+
+  before(:each) do
+    # Set up the ServiceNow reporting integration
+    master.apply_manifest(setup_manifest, catch_failures: true)
+    # Set up the site.pp file
+    set_sitepp_content(sitepp_content)
+  end
+  after(:each) do
+    set_sitepp_content('')
+  end
+
+  it 'has idempotent setup' do
+    master.idempotent_apply(setup_manifest)
+  end
+
+  shared_context 'incident creation test setup' do
+    let(:query) do
+      # This filters all report-processor generated incidents in descending
+      # order, meaning incidents[0] is the most recently created incident
+      'short_descriptionLIKEPuppet^ORDERBYDESCsys_created_on'
+    end
+
+    before(:each) do
+      IncidentHelpers.delete_incidents(query)
+    end
+    after(:each) do
+      IncidentHelpers.delete_incidents(query)
+    end
+  end
+
+  context 'with report status: unchanged' do
+    context 'and noop_pending: false' do
+      let(:sitepp_content) do
+        # Puppet should report that nothing happens
+        ''
+      end
+
+      it 'does nothing' do
+        num_incidents_before_puppet_run = IncidentHelpers.get_incidents('').length
+        trigger_puppet_run(master, acceptable_exit_codes: [0])
+        num_incidents_after_puppet_run = IncidentHelpers.get_incidents('').length
+        expect(num_incidents_after_puppet_run).to eql(num_incidents_before_puppet_run)
+      end
+    end
+
+    context 'and noop_pending: true' do
+      let(:sitepp_content) do
+        to_manifest(declare('notify', 'foo', 'noop' => true))
+      end
+
+      include_context 'incident creation test setup'
+
+      it 'creates an incident' do
+        trigger_puppet_run(master, acceptable_exit_codes: [0])
+        incident = IncidentHelpers.get_single_incident(query)
+        expect(incident['short_description']).to match(%r{pending changes})
+      end
+    end
+  end
+
+  context 'with report status: changed' do
+    let(:sitepp_content) do
+      to_manifest(declare('notify', 'foo'))
+    end
+
+    include_context 'incident creation test setup'
+
+    it 'creates an incident' do
+      trigger_puppet_run(master, acceptable_exit_codes: [2])
+      incident = IncidentHelpers.get_single_incident(query)
+      expect(incident['short_description']).to match(%r{changed})
+    end
+  end
+
+  context 'with report status: failed' do
+    let(:sitepp_content) do
+      to_manifest(declare('exec', 'foo', 'command' => '/bin/foo_command'))
+    end
+
+    include_context 'incident creation test setup'
+
+    it 'creates an incident' do
+      trigger_puppet_run(master, acceptable_exit_codes: [1, 4, 6])
+      incident = IncidentHelpers.get_single_incident(query)
+      expect(incident['short_description']).to match(%r{failed})
+    end
+  end
+
+  context 'user specifies a hiera-eyaml encrypted password' do
+    let(:params) do
+      default_params = super()
+      password = default_params.delete(:password)
+      default_params[:password] = master.run_shell("/opt/puppetlabs/puppet/bin/eyaml encrypt -s #{password} -o string").stdout
+      default_params
+    end
+    # Use a 'changed' report to test this.
+    let(:sitepp_content) do
+      to_manifest(declare('notify', 'foo'))
+    end
+
+    include_context 'incident creation test setup'
+
+    it 'still works' do
+      trigger_puppet_run(master, acceptable_exit_codes: [2])
+      incident = IncidentHelpers.get_single_incident(query)
+      expect(incident['short_description']).to match(%r{changed})
+    end
+  end
+end

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -19,40 +19,4 @@ describe 'servicenow_reporting_integration' do
   end
 
   it { is_expected.to compile }
-
-  context 'calculating the reports setting' do
-    # rspec-puppet caches the catalog in each test based on the params/facts.
-    # To clear the cache, we have to test each value in its own context block so
-    # that we can properly reset the params/facts. Since the params shouldn't
-    # change in each test, we'll be resetting the facts instead.
-    values = {
-      'none'                           => 'servicenow',
-      'foo'                            => 'foo, servicenow',
-      'foo, bar, baz'                  => 'foo, bar, baz, servicenow',
-      '  foo  '                        => 'foo, servicenow',
-      'foo  , bar  , baz'              => 'foo, bar, baz, servicenow',
-      'servicenow'                     => 'servicenow',
-      '  servicenow  '                 => '  servicenow  ',
-      'foo, servicenow'                => 'foo, servicenow',
-      '  foo, servicenow  '            => '  foo, servicenow  ',
-      'foo  , bar  , baz,  servicenow' => 'foo  , bar  , baz,  servicenow',
-      'foo, servicenow, bar'           => 'foo, servicenow, bar',
-    }
-    values.each do |value, expected_setting_value|
-      context "when setting = '#{value}'" do
-        let(:facts) do
-          # This is enough to reset the facts
-          {
-            '_report_settings_value' => value,
-          }
-        end
-
-        it do
-          allow(Puppet).to receive(:[]).with(anything).and_call_original
-          allow(Puppet).to receive(:[]).with(:reports).and_return(value)
-          is_expected.to contain_ini_setting('puppetserver puppetconf add servicenow report processor').with_value(expected_setting_value)
-        end
-      end
-    end
-  end
 end

--- a/spec/spec_helper_acceptance_local.rb
+++ b/spec/spec_helper_acceptance_local.rb
@@ -2,8 +2,14 @@
 
 require './spec/support/acceptance/helpers.rb'
 
-RSpec.configure do |_|
+RSpec.configure do |config|
   include TargetHelpers
+
+  config.before(:suite) do
+    # Stop the puppet service on the master to avoid edge-case conflicting
+    # Puppet runs (one triggered by service vs one we trigger)
+    master.run_shell('puppet resource service puppet ensure=stopped')
+  end
 end
 
 # TODO: This will cause some problems if we run the tests

--- a/spec/support/acceptance/servicenow/mock_instance.rb
+++ b/spec/support/acceptance/servicenow/mock_instance.rb
@@ -13,8 +13,7 @@ class MockServiceNowInstance < Sinatra::Base
 
   # Initialize the tables
   set :tables,
-      'cmdb_ci' => {},
-      'cmdb_ci_acc' => {}
+      'incident' => {}
 
   # Configure https
   set :server_settings,


### PR DESCRIPTION
These will be iterated on in future commits.

The changes here also include some fixes to get the acceptance tests
working. This includes using the ini_subsetting resource to declare the
'servicenow' report processor, which cleans up much of the manual cruft
that was initially added and also fixes a previous error where the 'store'
report processor was accidentally getting included in the 'reports' setting.

Signed-off-by: Enis Inan <enis.inan@puppet.com>