### PR TITLE
(PIE-291) UX for selecting reporting events

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -31,6 +31,10 @@
 #  The sys_id of the user assigned to the incident as specified in the
 #  sys_user table. Note that if assignment_group is also specified, then
 #  this must correspond to a user who is a member of the assignment_group.
+# @params [Array[Enum['failed_changes', 'corrective_changes', 'intentional_changes', 'all', 'none'], 1, 3]] incident_creation_report_statuses
+#   The kinds of report status attributes that can trigger an incident to be sent to Servicenow.
+#   Choose any of ['failed_changes', 'corrective_changes', 'intentional_changes', 'pending_changes', 'all', 'none', 'unchanged']
+#   You can also specify 'all' to create incidents for all report statuses or 'none' to completely turn off incident creation
 class servicenow_reporting_integration (
   String[1] $instance,
   String[1] $user,
@@ -45,6 +49,7 @@ class servicenow_reporting_integration (
   Optional[Integer] $urgency            = undef,
   Optional[String[1]] $assignment_group = undef,
   Optional[String[1]] $assigned_to      = undef,
+  Servicenow_reporting_integration::Statuses $incident_creation_report_attributes = ['failed_changes','corrective_changes'],
 ) {
   # Warning: These values are parameterized here at the top of this file, but the
   # path to the yaml file is hard coded in the report processor
@@ -73,20 +78,21 @@ class servicenow_reporting_integration (
       group   => 'pe-puppet',
       mode    => '0640',
       content => epp('servicenow_reporting_integration/servicenow_reporting.yaml.epp', {
-        instance                  => $instance,
-        user                      => $user,
-        password                  => $password,
-        pe_console_url            => $pe_console_url,
-        caller_id                 => $caller_id,
-        category                  => $category,
-        subcategory               => $subcategory,
-        contact_type              => $contact_type,
-        state                     => $state,
-        impact                    => $impact,
-        urgency                   => $urgency,
-        assignment_group          => $assignment_group,
-        assigned_to               => $assigned_to,
-        report_processor_checksum => $report_processor_checksum,
+        instance                            => $instance,
+        user                                => $user,
+        password                            => $password,
+        pe_console_url                      => $pe_console_url,
+        caller_id                           => $caller_id,
+        category                            => $category,
+        subcategory                         => $subcategory,
+        contact_type                        => $contact_type,
+        state                               => $state,
+        impact                              => $impact,
+        urgency                             => $urgency,
+        assignment_group                    => $assignment_group,
+        assigned_to                         => $assigned_to,
+        incident_creation_report_attributes => $incident_creation_report_attributes,
+        report_processor_checksum           => $report_processor_checksum,
       }),
       notify  => $settings_file_notify,
     }

--- a/spec/spec_helper_acceptance_local.rb
+++ b/spec/spec_helper_acceptance_local.rb
@@ -1,7 +1,8 @@
 # rubocop:disable Style/AccessorMethodName
 
-require './spec/support/acceptance/helpers.rb'
-require './spec/support/acceptance/shared_examples.rb'
+require 'support/acceptance/helpers'
+require 'support/acceptance/shared_examples'
+require 'support/acceptance/shared_contexts'
 
 RSpec.configure do |config|
   include TargetHelpers

--- a/spec/support/acceptance/shared_contexts.rb
+++ b/spec/support/acceptance/shared_contexts.rb
@@ -1,0 +1,31 @@
+
+RSpec.shared_context 'incident query setup' do
+  let(:query) do
+    # This filters all report-processor generated incidents in descending
+    # order, meaning incidents[0] is the most recently created incident
+    'short_descriptionLIKEPuppet^ORDERBYDESCsys_created_on'
+  end
+
+  before(:each) do
+    IncidentHelpers.delete_incidents(query)
+  end
+  after(:each) do
+    IncidentHelpers.delete_incidents(query)
+  end
+end
+
+RSpec.shared_context 'corrective change' do |noop = false|
+  before(:each) do
+    # For a change to be considered corrective, the resource needs to be managed and in
+    # the correct state at least one time, and then a drift from that state corrected.
+    # This setup manages a file and then drifts its state. The noop added to the
+    # resource will still mark the report as noop_pending.
+    set_sitepp_content(to_manifest(declare('file', '/tmp/test', 'content' => 'hello')))
+    trigger_puppet_run(master)
+    write_file(master, '/tmp/test', 'blah')
+
+    if noop
+      set_sitepp_content(declare('file', '/tmp/test', 'content' => 'hello', 'noop' => true))
+    end
+  end
+end

--- a/spec/support/acceptance/shared_examples.rb
+++ b/spec/support/acceptance/shared_examples.rb
@@ -1,8 +1,10 @@
 RSpec.shared_examples 'incident creation test' do |report_status|
   it 'creates an incident' do
     puppet_exit_codes, expected_short_description = case report_status.to_s
-                                                    when 'noop_pending'
+                                                    when 'pending'
                                                       [[0], %r{pending changes}]
+                                                    when 'unchanged'
+                                                      [[0], %r{unchanged}]
                                                     when 'changed'
                                                       [[2], %r{changed}]
                                                     when 'failed'
@@ -19,5 +21,14 @@ RSpec.shared_examples 'incident creation test' do |report_status|
     if respond_to?(:additional_incident_assertions)
       additional_incident_assertions.call(incident)
     end
+  end
+end
+
+RSpec.shared_examples 'no incident' do
+  it 'does not create an incident' do
+    num_incidents_before_puppet_run = IncidentHelpers.get_incidents('').length
+    trigger_puppet_run(master, acceptable_exit_codes: [0, 2])
+    num_incidents_after_puppet_run = IncidentHelpers.get_incidents('').length
+    expect(num_incidents_after_puppet_run).to eql(num_incidents_before_puppet_run)
   end
 end

--- a/spec/support/unit/reports/servicenow_spec_helpers.rb
+++ b/spec/support/unit/reports/servicenow_spec_helpers.rb
@@ -13,7 +13,7 @@ def expect_created_incident(expected_incident, expected_credentials = {})
     expect(actual_incident).to include(short_description: match(expected_incident[:short_description]))
     expect(actual_credentials).to include(expected_credentials)
 
-    new_mock_response(200, { 'sys_id' => 'foo_sys_id' }.to_json)
+    new_mock_response(200, { 'result' => { 'sys_id' => 'foo_sys_id', 'number' => 1 } }.to_json)
   end
 end
 

--- a/templates/servicenow_reporting.yaml.epp
+++ b/templates/servicenow_reporting.yaml.epp
@@ -11,6 +11,7 @@
       Optional[Integer] $urgency,
       Optional[String] $assignment_group,
       Optional[String] $assigned_to,
+      Array[String, 1, 4]$incident_creation_report_attributes,
       # Extra variables that _aren't_ part of the servicenow_reporting_integration
       # class' parameters go here
       String $report_processor_checksum,
@@ -30,4 +31,5 @@ impact: <%= $impact %>
 urgency: <%= $urgency %>
 assignment_group: <%= $assignment_group %>
 assigned_to: <%= $assigned_to %>
+incident_creation_report_attributes: <%= $incident_creation_report_attributes %>
 report_processor_checksum: <%= $report_processor_checksum %>

--- a/types/statuses.pp
+++ b/types/statuses.pp
@@ -1,0 +1,8 @@
+type Servicenow_reporting_integration::Statuses = Array[Enum['failed_changes',
+                                                             'corrective_changes',
+                                                             'intentional_changes',
+                                                             'pending_changes',
+                                                             'all',
+                                                             'none',
+                                                             'unchanged'
+                                                            ], 1]


### PR DESCRIPTION
This change allows the user to select the kinds of events that will
create an incident in servicenow. It also allows the user to decide if
noop runs will create an incident or not.

One problem that this module cannot solve for the moment is that on noop
runs, only corrective changes can generate incidents. An intentional
change cannot be detected on a noop run.

TODO:
- Update Documentation
- Contribute additional test cases for an uncovered option branches.