### PR TITLE
(PIE-304) Remove PE console reports link and link to PE console instead

### DIFF
--- a/lib/puppet/reports/servicenow.rb
+++ b/lib/puppet/reports/servicenow.rb
@@ -14,7 +14,10 @@ Puppet::Reports.register_report(:servicenow) do
     short_description_status = (status == 'unchanged') ? 'pending changes' : status
     incident_data = {
       short_description: "Puppet run report #{time} (status: #{short_description_status}) for node #{host}",
-      description: "See [code]<a class='web' target='_blank' href='https://#{settings_hash['pe_console']}/#/inspect/report/#{job_id}/metrics'>Report</a>[/code] for more details",
+      # Ideally, we'd like to link to the specific report here. However, fine-grained PE console links are
+      # unstable even for Y PE releases (e.g. the link is different for PE 2019.2 and PE 2019.8). Thus, the
+      # best and most stable solution we can do (for now) is the description you see here.
+      description: "See PE console for the full report. You can access the PE console at #{settings_hash['pe_console_url']}",
       caller: settings_hash['caller'],
       category: settings_hash['category'],
       contact_type: settings_hash['contact_type'],

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -8,10 +8,13 @@
 #   The username of the account
 # @param [String] password
 #   The password of the account
+# @param [String] pe_console_url
+#   The PE console url
 class servicenow_reporting_integration (
   String $instance,
   String $user,
   String $password,
+  String $pe_console_url,
 ) {
   # Warning: These values are parameterized here at the top of this file, but the
   # path to the yaml file is hard coded in the report processor
@@ -24,9 +27,10 @@ class servicenow_reporting_integration (
       group   => 'pe-puppet',
       mode    => '0640',
       content => epp('servicenow_reporting_integration/servicenow_reporting.yaml.epp', {
-        instance => $instance,
-        user     => $user,
-        password => $password,
+        instance       => $instance,
+        user           => $user,
+        password       => $password,
+        pe_console_url => $pe_console_url,
       }),
     }
   ])

--- a/spec/acceptance/reporting_spec.rb
+++ b/spec/acceptance/reporting_spec.rb
@@ -8,6 +8,7 @@ describe 'ServiceNow reporting' do
       instance: servicenow_instance.uri,
       user: servicenow_config['user'],
       password: servicenow_config['password'],
+      pe_console_url: "https://#{master.uri}",
     }
   end
   let(:setup_manifest) do
@@ -78,12 +79,7 @@ describe 'ServiceNow reporting' do
       end
 
       include_context 'incident creation test setup'
-
-      it 'creates an incident' do
-        trigger_puppet_run(master, acceptable_exit_codes: [0])
-        incident = IncidentHelpers.get_single_incident(query)
-        expect(incident['short_description']).to match(%r{pending changes})
-      end
+      include_examples 'incident creation test', 'noop_pending'
     end
   end
 
@@ -93,12 +89,7 @@ describe 'ServiceNow reporting' do
     end
 
     include_context 'incident creation test setup'
-
-    it 'creates an incident' do
-      trigger_puppet_run(master, acceptable_exit_codes: [2])
-      incident = IncidentHelpers.get_single_incident(query)
-      expect(incident['short_description']).to match(%r{changed})
-    end
+    include_examples 'incident creation test', 'changed'
   end
 
   context 'with report status: failed' do
@@ -107,12 +98,7 @@ describe 'ServiceNow reporting' do
     end
 
     include_context 'incident creation test setup'
-
-    it 'creates an incident' do
-      trigger_puppet_run(master, acceptable_exit_codes: [1, 4, 6])
-      incident = IncidentHelpers.get_single_incident(query)
-      expect(incident['short_description']).to match(%r{failed})
-    end
+    include_examples 'incident creation test', 'failed'
   end
 
   context 'user specifies a hiera-eyaml encrypted password' do
@@ -128,11 +114,6 @@ describe 'ServiceNow reporting' do
     end
 
     include_context 'incident creation test setup'
-
-    it 'still works' do
-      trigger_puppet_run(master, acceptable_exit_codes: [2])
-      incident = IncidentHelpers.get_single_incident(query)
-      expect(incident['short_description']).to match(%r{changed})
-    end
+    include_examples 'incident creation test', 'changed'
   end
 end

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -12,9 +12,10 @@ describe 'servicenow_reporting_integration' do
 
   let(:params) do
     {
-      'instance' => 'foo_instance',
-      'user' => 'foo_user',
-      'password' => 'foo_password',
+      'instance'       => 'foo_instance',
+      'user'           => 'foo_user',
+      'password'       => 'foo_password',
+      'pe_console_url' => 'foo_pe_console_url',
     }
   end
 

--- a/spec/spec_helper_acceptance_local.rb
+++ b/spec/spec_helper_acceptance_local.rb
@@ -1,6 +1,7 @@
 # rubocop:disable Style/AccessorMethodName
 
 require './spec/support/acceptance/helpers.rb'
+require './spec/support/acceptance/shared_examples.rb'
 
 RSpec.configure do |config|
   include TargetHelpers

--- a/spec/support/acceptance/shared_examples.rb
+++ b/spec/support/acceptance/shared_examples.rb
@@ -1,0 +1,19 @@
+RSpec.shared_examples 'incident creation test' do |report_status|
+  it 'creates an incident' do
+    puppet_exit_codes, expected_short_description = case report_status.to_s
+                                                    when 'noop_pending'
+                                                      [[0], %r{pending changes}]
+                                                    when 'changed'
+                                                      [[2], %r{changed}]
+                                                    when 'failed'
+                                                      [[1, 4, 6], %r{failed}]
+                                                    else
+                                                      raise "invalid report_status #{report_status}. Valid report statuses are 'noop_pending', 'changed', 'failed'"
+                                                    end
+
+    trigger_puppet_run(master, acceptable_exit_codes: puppet_exit_codes)
+    incident = IncidentHelpers.get_single_incident(query)
+    expect(incident['short_description']).to match(expected_short_description)
+    expect(incident['description']).to match(Regexp.new(Regexp.escape(master.uri)))
+  end
+end

--- a/spec/unit/reports/servicenow_spec.rb
+++ b/spec/unit/reports/servicenow_spec.rb
@@ -16,7 +16,7 @@ describe 'ServiceNow report processor' do
   end
 
   let(:settings_hash) do
-    { 'pe_console'       => 'test_console',
+    { 'pe_console_url'   => 'test_console',
       'caller'           => 'test_caller',
       'category'         => '1',
       'contact_type'     => '1',

--- a/templates/servicenow_reporting.yaml.epp
+++ b/templates/servicenow_reporting.yaml.epp
@@ -1,9 +1,11 @@
 <%- | String $instance,
       String $user,
       String $password,
+      String $pe_console_url,
 | -%>
 # managed by Puppet
 ---
 instance: <%= $instance %>
 user: <%= $user %>
 password: <%= $password %>
+pe_console_url: <%= $pe_console_url %>


### PR DESCRIPTION
Fine-grained PE console links like the reports link are unstable even
for Y PE releases. For example, the link is different for PE 2019.2
and PE 2019.8. Thus, the best and most stable solution is to make a note
that the report can be viewed in the PE console, and add a link to the
PE console's main URL. This commit implements that solution.

Signed-off-by: Enis Inan <enis.inan@puppet.com>