### PR TITLE
(PIE-307) Fill-in the remaining incident fields

### DIFF
--- a/lib/puppet/reports/servicenow.rb
+++ b/lib/puppet/reports/servicenow.rb
@@ -18,8 +18,9 @@ Puppet::Reports.register_report(:servicenow) do
       # unstable even for Y PE releases (e.g. the link is different for PE 2019.2 and PE 2019.8). Thus, the
       # best and most stable solution we can do (for now) is the description you see here.
       description: "See PE console for the full report. You can access the PE console at #{settings_hash['pe_console_url']}",
-      caller: settings_hash['caller'],
+      caller_id: settings_hash['caller_id'],
       category: settings_hash['category'],
+      subcategory: settings_hash['subcategory'],
       contact_type: settings_hash['contact_type'],
       state: settings_hash['state'],
       impact: settings_hash['impact'],

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -2,19 +2,49 @@
 #
 # @example
 #   include servicenow_reporting_integration
-# @param [String] instance
+# @param [String[1]] instance
 #   The FQDN of the ServiceNow instance
-# @param [String] user
+# @param [String[1]] user
 #   The username of the account
-# @param [String] password
+# @param [String[1]] password
 #   The password of the account
-# @param [String] pe_console_url
+# @param [String[1]] pe_console_url
 #   The PE console url
+# @param [String[1]] caller_id
+#  The sys_id of the incident's caller as specified in the sys_user table
+# @param [Optional[String[1]]] category
+#  The incident's category
+# @param [Optional[String[1]]] subcategory
+#  The incident's subcategory
+# @param [Optional[String[1]]] contact_type
+#  The incident's contact type
+# @param[Optional[Integer]] state
+#  The incident's state
+# @param[Optional[Integer]] impact
+#  The incident's impact
+# @param[Optional[Integer]] urgency
+#  The incident's urgency
+# @param [Optional[String[1]]] assignment_group
+#  The sys_id of the incident's assignment group as specified in the
+#  sys_user_group table
+# @param [Optional[String[1]]] assigned_to
+#  The sys_id of the user assigned to the incident as specified in the
+#  sys_user table. Note that if assignment_group is also specified, then
+#  this must correspond to a user who is a member of the assignment_group.
 class servicenow_reporting_integration (
-  String $instance,
-  String $user,
-  String $password,
-  String $pe_console_url,
+  String[1] $instance,
+  String[1] $user,
+  String[1] $password,
+  String[1] $pe_console_url,
+  String[1] $caller_id,
+  Optional[String[1]] $category         = undef,
+  Optional[String[1]] $subcategory      = undef,
+  Optional[String[1]] $contact_type     = undef,
+  Optional[Integer] $state              = undef,
+  Optional[Integer] $impact             = undef,
+  Optional[Integer] $urgency            = undef,
+  Optional[String[1]] $assignment_group = undef,
+  Optional[String[1]] $assigned_to      = undef,
 ) {
   # Warning: These values are parameterized here at the top of this file, but the
   # path to the yaml file is hard coded in the report processor
@@ -27,10 +57,19 @@ class servicenow_reporting_integration (
       group   => 'pe-puppet',
       mode    => '0640',
       content => epp('servicenow_reporting_integration/servicenow_reporting.yaml.epp', {
-        instance       => $instance,
-        user           => $user,
-        password       => $password,
-        pe_console_url => $pe_console_url,
+        instance         => $instance,
+        user             => $user,
+        password         => $password,
+        pe_console_url   => $pe_console_url,
+        caller_id        => $caller_id,
+        category         => $category,
+        subcategory      => $subcategory,
+        contact_type     => $contact_type,
+        state            => $state,
+        impact           => $impact,
+        urgency          => $urgency,
+        assignment_group => $assignment_group,
+        assigned_to      => $assigned_to,
       }),
     }
   ])

--- a/spec/acceptance/reporting_spec.rb
+++ b/spec/acceptance/reporting_spec.rb
@@ -1,6 +1,25 @@
 require 'spec_helper_acceptance'
+# rubocop:disable Metrics/LineLength
 
 describe 'ServiceNow reporting' do
+  # Make this a top-level variable instead of a 'let' to avoid redundant
+  # computation. Note that the kaller 'let' variable is necessary for the
+  # example groups.
+  kaller_record = begin
+    task_params = {
+      'table' => 'sys_user',
+      'url_params' => {
+        'sysparm_limit' => 1,
+      },
+    }
+    users = servicenow_instance.run_bolt_task('servicenow_tasks::get_records', task_params).result['result']
+    if users.empty?
+      raise "cannot calculate the caller_id: there are no users available on the ServiceNow instance #{servicenow_instance.uri} (table sys_user)"
+    end
+    users[0]
+  end
+
+  let(:kaller) { kaller_record }
   let(:params) do
     servicenow_config = servicenow_instance.bolt_config['remote']
 
@@ -9,6 +28,7 @@ describe 'ServiceNow reporting' do
       user: servicenow_config['user'],
       password: servicenow_config['password'],
       pe_console_url: "https://#{master.uri}",
+      caller_id: kaller['sys_id'],
     }
   end
   let(:setup_manifest) do
@@ -115,5 +135,78 @@ describe 'ServiceNow reporting' do
 
     include_context 'incident creation test setup'
     include_examples 'incident creation test', 'changed'
+  end
+
+  context 'user specifies the remaining incident fields' do
+    # Make this a top-level variable instead of a 'let' to avoid redundant
+    # computation. Note that the ug_pair 'let' variable is necessary for the
+    # example groups.
+    ug_pair_record = begin
+      task_params = {
+        'table' => 'sys_user_grmember',
+        'url_params' => {
+          'sysparm_exclude_reference_link' => true,
+        },
+      }
+      pairs = servicenow_instance.run_bolt_task('servicenow_tasks::get_records', task_params).result['result']
+      if pairs.empty?
+        raise "cannot calculate the ug_pair: there are no pairs available on the ServiceNow instance #{servicenow_instance.uri} (table sys_user_grmember)"
+      end
+
+      pair = pairs.find do |p|
+        # We choose a different user so we can properly test the 'assigned_to' parameter
+        p['user'] != kaller_record['name']
+      end
+      unless pair
+        raise "cannot calculate the ug_pair: there are no pairs available on the ServiceNow instance #{servicenow_instance.uri} (table sys_user_grmember) s.t. pair['user'] != #{kaller['name']} (the calculated caller)"
+      end
+
+      pair
+    end
+
+    let(:ug_pair) { ug_pair_record }
+    let(:params) do
+      # ps => params
+      ps = super()
+
+      ps['category'] = 'software'
+      ps['subcategory'] = 'os'
+      ps['contact_type'] = 'email'
+      ps['state'] = 8
+      ps['impact'] = 1
+      ps['urgency'] = 2
+      ps['assignment_group'] = pair['group']
+      ps['assigned_to'] = pair['user']
+
+      ps
+    end
+    # Use a 'changed' report to test this
+    let(:sitepp_content) do
+      to_manifest(declare('notify', 'foo'))
+    end
+
+    include_context 'incident creation test setup'
+    include_examples 'incident creation test', 'changed' do
+      let(:additional_incident_assertions) do
+        ->(incident) {
+          expect(incident['category']).to eql('software')
+          expect(incident['subcategory']).to eql('os')
+          expect(incident['contact_type']).to eql('email')
+
+          # Even though these are Integer fields on a real ServiceNow instance,
+          # the table API still returns them as strings. However, the mock
+          # ServiceNow instance returns them as integers to keep the mocking
+          # simple. Thus, we just do a quick 'to_i' conversion so that these
+          # assertions pass on both a real ServiceNow instance and on the mock
+          # ServiceNow instance.
+          expect(incident['state'].to_i).to be(8)
+          expect(incident['impact'].to_i).to be(1)
+          expect(incident['urgency'].to_i).to be(2)
+
+          expect(incident['assignment_group']).to eql(ug_pair['group'])
+          expect(incident['assigned_to']).to eql(ug_pair['user'])
+        }
+      end
+    end
   end
 end

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -16,8 +16,31 @@ describe 'servicenow_reporting_integration' do
       'user'           => 'foo_user',
       'password'       => 'foo_password',
       'pe_console_url' => 'foo_pe_console_url',
+      'caller_id'      => 'foo_caller_id',
     }
   end
 
-  it { is_expected.to compile }
+  context 'without the optional parameters' do
+    it { is_expected.to compile }
+  end
+
+  context 'with the optional parameters' do
+    let(:params) do
+      # ps => params
+      ps = super()
+
+      ps['category'] = 'foo_category'
+      ps['subcategory'] = 'foo_subcategory'
+      ps['contact_type'] = 'foo_contact_type'
+      ps['state'] = 1
+      ps['impact'] = 1
+      ps['urgency'] = 1
+      ps['assignment_group'] = 'foo_assignment_group'
+      ps['assigned_to'] = 'foo_assigned_to'
+
+      ps
+    end
+
+    it { is_expected.to compile }
+  end
 end

--- a/spec/support/acceptance/helpers.rb
+++ b/spec/support/acceptance/helpers.rb
@@ -85,7 +85,7 @@ module IncidentHelpers
       'table' => 'incident',
       'url_params' => {
         'sysparm_query' => query,
-        'sysparm_display_value' => true,
+        'sysparm_exclude_reference_link' => true,
       },
     }
 
@@ -95,7 +95,7 @@ module IncidentHelpers
   module_function :get_incidents
 
   def get_single_incident(query)
-    snow_err_msg_prefix = "On ServiceNow instance #{servicenow_instance.uri} with query #{query}"
+    snow_err_msg_prefix = "On ServiceNow instance #{servicenow_instance.uri} with query '#{query}'"
 
     incidents = IncidentHelpers.get_incidents(query)
     raise "#{snow_err_msg_prefix} expected incident matching query but none was found" if incidents.empty?

--- a/spec/support/acceptance/shared_examples.rb
+++ b/spec/support/acceptance/shared_examples.rb
@@ -15,5 +15,9 @@ RSpec.shared_examples 'incident creation test' do |report_status|
     incident = IncidentHelpers.get_single_incident(query)
     expect(incident['short_description']).to match(expected_short_description)
     expect(incident['description']).to match(Regexp.new(Regexp.escape(master.uri)))
+    expect(incident['caller_id']).to eql(kaller['sys_id'])
+    if respond_to?(:additional_incident_assertions)
+      additional_incident_assertions.call(incident)
+    end
   end
 end

--- a/templates/servicenow_reporting.yaml.epp
+++ b/templates/servicenow_reporting.yaml.epp
@@ -2,6 +2,16 @@
       String $user,
       String $password,
       String $pe_console_url,
+      String $caller_id,
+      Optional[String] $category,
+      Optional[String] $subcategory,
+      Optional[String] $contact_type,
+      Optional[Integer] $state,
+      Optional[Integer] $impact,
+      Optional[Integer] $urgency,
+      Optional[String] $assignment_group,
+      Optional[String] $assigned_to,
+
 | -%>
 # managed by Puppet
 ---
@@ -9,3 +19,12 @@ instance: <%= $instance %>
 user: <%= $user %>
 password: <%= $password %>
 pe_console_url: <%= $pe_console_url %>
+caller_id: <%= $caller_id %>
+category: <%= $category %>
+subcategory: <%= $subcategory %>
+contact_type: <%= $contact_type %>
+state: <%= $state %>
+impact: <%= $impact %>
+urgency: <%= $urgency %>
+assignment_group: <%= $assignment_group %>
+assigned_to: <%= $assigned_to %>


### PR DESCRIPTION
These are the incident fields that appear in ServiceNow's default
incident UI. Some things to note:

* caller_id is a required parameter because it is a required field in
incident creation.

* incident_state (used in the report2snow module) is not needed.
Based on
https://community.servicenow.com/community?id=community_question&sys_id=34caf657db2e534023f4a345ca96198c,
state is enough b/c there's rules syncing incident_state and state.

* severity (used in report2snow) doesn't show up in the default incident
UIs, so it is omitted until a customer asks for it.

* priority (set in report2snow) is typically calculated from impact and
urgency. Thus, it is also omitted until a customer asks for it.

* escalation (set in report2snow) is a legacy field according to https://community.servicenow.com/community?id=community_question&sys_id=3b604b87db3c674067a72926ca9619b1

* location (shown in one of the default UIs) seems a bit strange for a
Puppet report, so it is omitted until a customer asks for it.

Note that the UX here will likely change in the future to allow for more
fine-grained configuration (e.g. configure these fields on report status
vs. toplevel).

Signed-off-by: Enis Inan <enis.inan@puppet.com>