### PR TITLE
(PIE-308) Sync report processor changes with puppetserver

### DIFF
--- a/lib/puppet/functions/servicenow_reporting_integration/check_report_processor.rb
+++ b/lib/puppet/functions/servicenow_reporting_integration/check_report_processor.rb
@@ -1,0 +1,35 @@
+Puppet::Functions.create_function(:'servicenow_reporting_integration::check_report_processor') do
+  require 'yaml'
+
+  dispatch :check_report_processor do
+    param 'String', :settings_file_path
+  end
+
+  def check_report_processor(settings_file_path)
+    module_dir = call_function('module_directory', 'servicenow_reporting_integration')
+    report_processor_path = "#{module_dir}/lib/puppet/reports/servicenow.rb"
+
+    # Get the report processor's current checksum
+    current_checksum = nil
+    begin
+      current_checksum = Puppet::Util::Checksums.sha256_file(report_processor_path)
+    rescue StandardError => e
+      raise Puppet::Error, "failed to calculate the 'servicenow' report processor's current sha256 checksum: #{e}"
+    end
+
+    # Get the stored checksum (if it exists)
+    stored_checksum = nil
+    begin
+      settings_hash = YAML.load_file(settings_file_path)
+      stored_checksum = settings_hash['report_processor_checksum'].to_s
+    rescue StandardError
+      # Assume that an error means that the stored checksum doesn't exist (possible if e.g. the settings
+      # file hasn't been created yet). We leave the handling of more serious errors (like 'invalid permissions')
+      # to the File[<settings_file_path>] resource.
+      stored_checksum = ''
+    end
+    report_processor_changed = (stored_checksum != current_checksum) ? true : false
+
+    [report_processor_changed, current_checksum]
+  end
+end

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -50,27 +50,45 @@ class servicenow_reporting_integration (
   # path to the yaml file is hard coded in the report processor
   $puppet_base = '/etc/puppetlabs/puppet'
 
+  # If the report processor changed between module versions then we need to restart puppetserver.
+  # To detect when the report processor changed, we compare its current checksum with the checksum
+  # stored in the settings file. This is handled by the 'check_report_processor' custom function.
+  #
+  # Note that the $report_processor_changed variable is necessary to avoid restarting pe-puppetserver
+  # everytime the settings file changes due to non-report processor reasons (like e.g. if the ServiceNow
+  # credentials change). We also return the current report processor checksum so that we can persist it
+  # in the settings file.
+  $settings_file_path = "${puppet_base}/servicenow_reporting.yaml"
+  [$report_processor_changed, $report_processor_checksum] = servicenow_reporting_integration::check_report_processor($settings_file_path)
+  if $report_processor_changed {
+    # Restart puppetserver to pick-up the changes
+    $settings_file_notify = [Service['pe-puppetserver']]
+  } else {
+    $settings_file_notify = []
+  }
   $resource_dependencies = flatten([
-    file { "${puppet_base}/servicenow_reporting.yaml":
+    file { $settings_file_path:
       ensure  => file,
       owner   => 'pe-puppet',
       group   => 'pe-puppet',
       mode    => '0640',
       content => epp('servicenow_reporting_integration/servicenow_reporting.yaml.epp', {
-        instance         => $instance,
-        user             => $user,
-        password         => $password,
-        pe_console_url   => $pe_console_url,
-        caller_id        => $caller_id,
-        category         => $category,
-        subcategory      => $subcategory,
-        contact_type     => $contact_type,
-        state            => $state,
-        impact           => $impact,
-        urgency          => $urgency,
-        assignment_group => $assignment_group,
-        assigned_to      => $assigned_to,
+        instance                  => $instance,
+        user                      => $user,
+        password                  => $password,
+        pe_console_url            => $pe_console_url,
+        caller_id                 => $caller_id,
+        category                  => $category,
+        subcategory               => $subcategory,
+        contact_type              => $contact_type,
+        state                     => $state,
+        impact                    => $impact,
+        urgency                   => $urgency,
+        assignment_group          => $assignment_group,
+        assigned_to               => $assigned_to,
+        report_processor_checksum => $report_processor_checksum,
       }),
+      notify  => $settings_file_notify,
     }
   ])
 
@@ -82,6 +100,10 @@ class servicenow_reporting_integration (
     setting              => 'reports',
     subsetting           => 'servicenow',
     subsetting_separator => ',',
+    # Note that Puppet refreshes resources only once so multiple notifies
+    # in a single run are safe. In our case, this means that if the settings
+    # file resource and the ini_subsetting resource both notify pe-puppetserver,
+    # then pe-puppetserver will be refreshed (restarted) only once.
     notify               => Service['pe-puppetserver'],
     require              => $resource_dependencies,
   }

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'spec_helper'
+require 'securerandom'
 
 describe 'servicenow_reporting_integration' do
   let(:pre_condition) do
@@ -17,6 +18,16 @@ describe 'servicenow_reporting_integration' do
       'password'       => 'foo_password',
       'pe_console_url' => 'foo_pe_console_url',
       'caller_id'      => 'foo_caller_id',
+    }
+  end
+  # rspec-puppet caches the catalog in each test based on the params/facts.
+  # However, some of the tests reuse the same params (like the report processor
+  # tests). Thus to clear the cache, we have to reset the facts since the params
+  # don't change.
+  let(:facts) do
+    # This is enough to reset the cache
+    {
+      '_cache_reset_' => SecureRandom.uuid,
     }
   end
 
@@ -42,5 +53,47 @@ describe 'servicenow_reporting_integration' do
     end
 
     it { is_expected.to compile }
+  end
+
+  context 'checking the report processor for any changes' do
+    let(:settings_file_path) { '/etc/puppetlabs/puppet/servicenow_reporting.yaml' }
+
+    context 'when the checksum calculation fails' do
+      before(:each) do
+        allow(Puppet::Util::Checksums).to receive(:sha256_file).with(%r{reports.*servicenow}).and_raise('failed to access file')
+      end
+
+      it { is_expected.to compile.and_raise_error(%r{access.*file}) }
+    end
+
+    context 'when the module fails to access the settings file' do
+      before(:each) do
+        allow(Puppet::Util::Checksums).to receive(:sha256_file).with(%r{reports.*servicenow}).and_return('report_checksum')
+        allow(YAML).to receive(:load_file).with(settings_file_path).and_raise('failed to access file')
+      end
+
+      it { is_expected.to contain_file(settings_file_path).with_content(%r{report_processor_checksum: report_checksum}) }
+      it { is_expected.to contain_file(settings_file_path).that_notifies('Service[pe-puppetserver]') }
+    end
+
+    context 'when the stored checksum does not match the current checksum' do
+      before(:each) do
+        allow(Puppet::Util::Checksums).to receive(:sha256_file).with(%r{reports.*servicenow}).and_return('report_checksum')
+        allow(YAML).to receive(:load_file).with(settings_file_path).and_return('report_processor_checksum' => 'stored_checksum')
+      end
+
+      it { is_expected.to contain_file(settings_file_path).with_content(%r{report_processor_checksum: report_checksum}) }
+      it { is_expected.to contain_file(settings_file_path).that_notifies('Service[pe-puppetserver]') }
+    end
+
+    context 'when the stored checksum matches the current checksum' do
+      before(:each) do
+        allow(Puppet::Util::Checksums).to receive(:sha256_file).with(%r{reports.*servicenow}).and_return('report_checksum')
+        allow(YAML).to receive(:load_file).with(settings_file_path).and_return('report_processor_checksum' => 'report_checksum')
+      end
+
+      it { is_expected.to contain_file(settings_file_path).with_content(%r{report_processor_checksum: report_checksum}) }
+      it { is_expected.not_to contain_file(settings_file_path).that_notifies(['Service[pe-puppetserver]']) }
+    end
   end
 end

--- a/spec/spec_helper_acceptance_local.rb
+++ b/spec/spec_helper_acceptance_local.rb
@@ -23,7 +23,14 @@ def set_sitepp_content(manifest)
   }
   HERE
 
-  master.run_shell("echo '#{content}' > /etc/puppetlabs/code/environments/production/manifests/site.pp")
+  write_file(master, '/etc/puppetlabs/code/environments/production/manifests/site.pp', content)
+end
+
+def write_file(target, dest, content)
+  # Litmus doesn't have a 'write_file' helper so we write our own
+  # by taking advtange of create_manifest_file
+  path = target.create_manifest_file(content)
+  target.run_shell("mv #{path} #{dest}")
 end
 
 def trigger_puppet_run(target, acceptable_exit_codes: [0, 2])

--- a/templates/servicenow_reporting.yaml.epp
+++ b/templates/servicenow_reporting.yaml.epp
@@ -11,7 +11,9 @@
       Optional[Integer] $urgency,
       Optional[String] $assignment_group,
       Optional[String] $assigned_to,
-
+      # Extra variables that _aren't_ part of the servicenow_reporting_integration
+      # class' parameters go here
+      String $report_processor_checksum,
 | -%>
 # managed by Puppet
 ---
@@ -28,3 +30,4 @@ impact: <%= $impact %>
 urgency: <%= $urgency %>
 assignment_group: <%= $assignment_group %>
 assigned_to: <%= $assigned_to %>
+report_processor_checksum: <%= $report_processor_checksum %>


### PR DESCRIPTION
We could do the syncing by flushing puppetserver's jruby pool via an API
call (and hence avoid the restart). However, that method results in more complicated
code for little gain.

Note that this is an issue for report processors in general. It is
captured in SERVER-2844.

Signed-off-by: Enis Inan <enis.inan@puppet.com>