### PR TITLE
(PIE-308) Use metadata.json version when checking report processor

### DIFF
--- a/lib/puppet/functions/servicenow_reporting_integration/check_report_processor.rb
+++ b/lib/puppet/functions/servicenow_reporting_integration/check_report_processor.rb
@@ -1,4 +1,5 @@
 Puppet::Functions.create_function(:'servicenow_reporting_integration::check_report_processor') do
+  require 'json'
   require 'yaml'
 
   dispatch :check_report_processor do
@@ -7,29 +8,32 @@ Puppet::Functions.create_function(:'servicenow_reporting_integration::check_repo
 
   def check_report_processor(settings_file_path)
     module_dir = call_function('module_directory', 'servicenow_reporting_integration')
-    report_processor_path = "#{module_dir}/lib/puppet/reports/servicenow.rb"
+    metadata_json_path = "#{module_dir}/metadata.json"
 
-    # Get the report processor's current checksum
-    current_checksum = nil
+    # Get the report processor's current version (should be the same as the version
+    # in the metadata.json file)
+    current_version = nil
     begin
-      current_checksum = Puppet::Util::Checksums.sha256_file(report_processor_path)
+      raw_metadata_json = Puppet::FileSystem.read(metadata_json_path)
+      metadata_json = JSON.parse(raw_metadata_json)
+      current_version = metadata_json['version']
     rescue StandardError => e
-      raise Puppet::Error, "failed to calculate the 'servicenow' report processor's current sha256 checksum: #{e}"
+      raise Puppet::Error, "failed to calculate the 'servicenow' report processor's current version: #{e}"
     end
 
-    # Get the stored checksum (if it exists)
-    stored_checksum = nil
+    # Get the stored version (if it exists)
+    stored_version = nil
     begin
       settings_hash = YAML.load_file(settings_file_path)
-      stored_checksum = settings_hash['report_processor_checksum'].to_s
+      stored_version = settings_hash['report_processor_version'].to_s
     rescue StandardError
-      # Assume that an error means that the stored checksum doesn't exist (possible if e.g. the settings
+      # Assume that an error means that the stored version doesn't exist (possible if e.g. the settings
       # file hasn't been created yet). We leave the handling of more serious errors (like 'invalid permissions')
       # to the File[<settings_file_path>] resource.
-      stored_checksum = ''
+      stored_version = ''
     end
-    report_processor_changed = (stored_checksum != current_checksum) ? true : false
+    report_processor_changed = (stored_version != current_version) ? true : false
 
-    [report_processor_changed, current_checksum]
+    [report_processor_changed, current_version]
   end
 end

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -87,15 +87,15 @@ class servicenow_reporting_integration (
   $puppet_base = '/etc/puppetlabs/puppet'
 
   # If the report processor changed between module versions then we need to restart puppetserver.
-  # To detect when the report processor changed, we compare its current checksum with the checksum
+  # To detect when the report processor changed, we compare its current version with the version
   # stored in the settings file. This is handled by the 'check_report_processor' custom function.
   #
   # Note that the $report_processor_changed variable is necessary to avoid restarting pe-puppetserver
   # everytime the settings file changes due to non-report processor reasons (like e.g. if the ServiceNow
-  # credentials change). We also return the current report processor checksum so that we can persist it
+  # credentials change). We also return the current report processor version so that we can persist it
   # in the settings file.
   $settings_file_path = "${puppet_base}/servicenow_reporting.yaml"
-  [$report_processor_changed, $report_processor_checksum] = servicenow_reporting_integration::check_report_processor($settings_file_path)
+  [$report_processor_changed, $report_processor_version] = servicenow_reporting_integration::check_report_processor($settings_file_path)
   if $report_processor_changed {
     # Restart puppetserver to pick-up the changes
     $settings_file_notify = [Service['pe-puppetserver']]
@@ -129,7 +129,7 @@ class servicenow_reporting_integration (
       assignment_group             => $assignment_group,
       assigned_to                  => $assigned_to,
       incident_creation_conditions => $incident_creation_conditions ,
-      report_processor_checksum    => $report_processor_checksum,
+      report_processor_version     => $report_processor_version,
       }),
     notify       => $settings_file_notify,
   }

--- a/spec/acceptance/reporting_spec.rb
+++ b/spec/acceptance/reporting_spec.rb
@@ -269,6 +269,9 @@ describe 'ServiceNow reporting' do
     let(:reports_dir) do
       '/etc/puppetlabs/code/environments/production/modules/servicenow_reporting_integration/lib/puppet/reports'
     end
+    let(:old_metadata_json) do
+      get_metadata_json
+    end
 
     include_context 'reporting test setup'
 
@@ -276,10 +279,15 @@ describe 'ServiceNow reporting' do
       master.run_shell("rm -f #{created_file_path}")
       master.run_shell("mv #{reports_dir}/servicenow.rb #{reports_dir}/servicenow_current.rb")
       write_file(master, "#{reports_dir}/servicenow.rb", report_processor_implementation)
+
+      # Update the metadata.json version to simulate a report processor change
+      new_metadata_json = old_metadata_json.merge('version' => '0.0.0')
+      write_file(master, METADATA_JSON_PATH, JSON.pretty_generate(new_metadata_json))
     end
     after(:each) do
       master.run_shell("rm -f #{created_file_path}")
       master.run_shell("mv #{reports_dir}/servicenow_current.rb #{reports_dir}/servicenow.rb")
+      write_file(master, METADATA_JSON_PATH, JSON.pretty_generate(old_metadata_json))
     end
 
     it 'picks up those changes' do

--- a/spec/spec_helper_acceptance_local.rb
+++ b/spec/spec_helper_acceptance_local.rb
@@ -78,3 +78,10 @@ end
 def to_manifest(*declarations)
   declarations.join("\n")
 end
+
+METADATA_JSON_PATH = '/etc/puppetlabs/code/environments/production/modules/servicenow_reporting_integration/metadata.json'.freeze
+
+def get_metadata_json
+  raw_metadata_json = master.run_shell("cat #{METADATA_JSON_PATH}").stdout.chomp
+  JSON.parse(raw_metadata_json)
+end

--- a/templates/servicenow_reporting.yaml.epp
+++ b/templates/servicenow_reporting.yaml.epp
@@ -15,7 +15,7 @@
       Array[String]$incident_creation_conditions,
       # Extra variables that _aren't_ part of the servicenow_reporting_integration
       # class' parameters go here
-      String $report_processor_checksum,
+      String $report_processor_version,
 | -%>
 # managed by Puppet
 ---
@@ -34,4 +34,4 @@ urgency: <%= $urgency %>
 assignment_group: <%= $assignment_group %>
 assigned_to: <%= $assigned_to %>
 incident_creation_conditions: <%= $incident_creation_conditions %>
-report_processor_checksum: <%= $report_processor_checksum %>
+report_processor_version: <%= $report_processor_version %>


### PR DESCRIPTION
This is a better long-term solution and also fixes the underlying bug
with the existing checksum calculation (where the latter failed to pick
up changes in dependencies).

Signed-off-by: Enis Inan <enis.inan@puppet.com>