### PR TITLE
(PIE-314) Set settings file location via Puppet confdir

### DIFF
--- a/lib/puppet/util/servicenow.rb
+++ b/lib/puppet/util/servicenow.rb
@@ -20,7 +20,7 @@ module Puppet::Util::Servicenow
   end
   module_function :sn_log_entry
 
-  def settings(settings_file = '/etc/puppetlabs/puppet/servicenow_reporting.yaml')
+  def settings(settings_file = Puppet[:confdir] + '/servicenow_reporting.yaml')
     settings_hash = YAML.load_file(settings_file)
 
     # Since we also support hiera-eyaml encrypted passwords, we'll want to decrypt

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -98,7 +98,7 @@ describe 'servicenow_reporting_integration' do
   end
 
   context 'checking the report processor for any changes' do
-    let(:settings_file_path) { '/etc/puppetlabs/puppet/servicenow_reporting.yaml' }
+    let(:settings_file_path) { Puppet[:confdir] + '/servicenow_reporting.yaml' }
 
     before(:each) do
       # This handles cases when Puppet::FileSystem is called outside of our


### PR DESCRIPTION
This updates the settings function look for the settings file
(servicenow_reporting.yaml) in Puppet[:confdir] as well as updates
init.pp to look in settings::confdir.