### PR TITLE
(PIE-306) Timestampt Too Verbose

### DIFF
--- a/lib/puppet/reports/servicenow.rb
+++ b/lib/puppet/reports/servicenow.rb
@@ -9,6 +9,7 @@ Puppet::Reports.register_report(:servicenow) do
     settings_hash = settings
 
     incident_creation_conditions = settings_hash['incident_creation_conditions']
+
     unless incident_creation_conditions.is_a?(Array)
       raise "settings['incident_creation_conditions'] must be an array, got #{incident_creation_conditions}"
     end
@@ -23,7 +24,7 @@ Puppet::Reports.register_report(:servicenow) do
 
     short_description_status = noop_pending ? 'pending changes' : status
     incident_data = {
-      short_description: "Puppet run report #{time} (status: #{short_description_status}) for node #{host}",
+      short_description: "Puppet run report (status: #{short_description_status}) for node #{host} (report time: #{format_report_timestamp(time, metrics)})",
       # Ideally, we'd like to link to the specific report here. However, fine-grained PE console links are
       # unstable even for Y PE releases (e.g. the link is different for PE 2019.2 and PE 2019.8). Thus, the
       # best and most stable solution we can do (for now) is the description you see here.

--- a/lib/puppet/util/servicenow.rb
+++ b/lib/puppet/util/servicenow.rb
@@ -144,4 +144,11 @@ module Puppet::Util::Servicenow
     !satisfied_conditions.empty?
   end
   module_function :create_incident?
+
+  def format_report_timestamp(time, metrics)
+    total_time = time + metrics['time']['total']
+    short_date_time = total_time.strftime('%F %H:%M:%S %Z')
+    short_date_time.gsub('UTC', 'Z')
+  end
+  module_function :format_report_timestamp
 end

--- a/spec/support/unit/reports/servicenow_spec_helpers.rb
+++ b/spec/support/unit/reports/servicenow_spec_helpers.rb
@@ -39,5 +39,8 @@ def expect_created_incident(expected_incident, expected_credentials = {})
 end
 
 def short_description_regex(status)
-  Regexp.new("Puppet.*#{processor.time}.*#{Regexp.escape(status)}.*#{processor.host}")
+  # Since the formatted time string is regex only precise to the minute, the unit tests
+  # execute fast enough that race conditions and intermittent failures shouldn't
+  # be a problem.
+  Regexp.new(%r{Puppet.*#{Regexp.escape(status)}.*#{processor.host} \(report time: #{Time.now.strftime('%F %H:%M')}.*\)})
 end

--- a/spec/unit/reports/servicenow_spec.rb
+++ b/spec/unit/reports/servicenow_spec.rb
@@ -13,6 +13,8 @@ describe 'ServiceNow report processor' do
     allow(processor).to receive(:time).and_return '00:00:00'
     allow(processor).to receive(:host).and_return 'host'
     allow(processor).to receive(:job_id).and_return '1'
+    allow(processor).to receive(:time).and_return(Time.now)
+    allow(processor).to receive(:metrics).and_return('time' => { 'total' => 0 })
     processor
   end
 


### PR DESCRIPTION
This change formats the timestamp slightly better, and moves it to the
back of the short description.

The improved formatting should be the actual time displayed to the user
when the go to the `Reports` screen in the PE Console. This should
allow users searching for a particular report that caused an incident to
`ctrl-f` search the reports screen to find the correct one based on this
improved timestamp.

Moving the stamp tto back of the string allows the user to parse the
important information about severity and target first.

In the console, when the timezone is `UTC`, that value is replaced by
the string `Z`. Since that seems to be the most common time zone name
mapping I did that one manually, but any other time zones will get the
time zone abreviation value that Ruby has directly.