### PR TITLE
(PIE-311) Fine grain description of the incident creation reason

### DIFF
--- a/lib/puppet/reports/servicenow.rb
+++ b/lib/puppet/reports/servicenow.rb
@@ -16,7 +16,9 @@ Puppet::Reports.register_report(:servicenow) do
 
     Puppet.info(sn_log_entry("incident creation conditions: #{incident_creation_conditions}"))
 
-    unless create_incident?(status, resource_statuses, incident_creation_conditions)
+    satisfied_conditions = calculate_satisfied_conditions(status, resource_statuses, incident_creation_conditions)
+
+    if satisfied_conditions.empty?
       Puppet.info(sn_log_entry('decision: Do not create incident'))
       # do not create an incident
       return false
@@ -28,7 +30,7 @@ Puppet::Reports.register_report(:servicenow) do
       # Ideally, we'd like to link to the specific report here. However, fine-grained PE console links are
       # unstable even for Y PE releases (e.g. the link is different for PE 2019.2 and PE 2019.8). Thus, the
       # best and most stable solution we can do (for now) is the description you see here.
-      description: "See PE console for the full report. You can access the PE console at #{settings_hash['pe_console_url']}",
+      description: incident_description(satisfied_conditions, settings_hash),
       caller_id: settings_hash['caller_id'],
       category: settings_hash['category'],
       subcategory: settings_hash['subcategory'],

--- a/spec/support/unit/reports/servicenow_spec_helpers.rb
+++ b/spec/support/unit/reports/servicenow_spec_helpers.rb
@@ -32,6 +32,8 @@ def expect_created_incident(expected_incident, expected_credentials = {})
     # Matching key-by-key makes it easier to debug test failures
     expect(actual_incident[:short_description]).to match(expected_incident[:short_description])
 
+    expect(actual_incident[:description]).to match(expected_incident[:description])
+
     expect(actual_credentials).to include(expected_credentials)
 
     new_mock_response(200, { 'result' => { 'sys_id' => 'foo_sys_id', 'number' => 1 } }.to_json)

--- a/spec/support/unit/reports/shared_examples.rb
+++ b/spec/support/unit/reports/shared_examples.rb
@@ -16,8 +16,11 @@ RSpec.shared_examples 'incident creation test' do |report_status|
                                    raise "invalid report_status #{report_status}. Valid report statuses are 'noop_pending', 'changed', 'failed'"
                                  end
 
+    expected_description = %r{#{settings_hash['incident_creation_conditions'].join(', ')}.*#{settings_hash['pe_console_url']}}
+
     expected_incident = {
       short_description: expected_short_description,
+      description: expected_description,
     }
     expect_created_incident(expected_incident, expected_credentials)
 

--- a/spec/unit/reports/servicenow_spec.rb
+++ b/spec/unit/reports/servicenow_spec.rb
@@ -245,6 +245,7 @@ describe 'ServiceNow report processor' do
         it 'decrypts the password' do
           expected_incident = {
             short_description: short_description_regex('failed'),
+            description: 'This incident was created based on the following conditions: failures. See the PE console for the full report. You can access the PE console at test_console.',
           }
           expect_created_incident(expected_incident, expected_credentials)
           processor.process
@@ -262,6 +263,7 @@ describe 'ServiceNow report processor' do
         it 'decrypts the password' do
           expected_incident = {
             short_description: short_description_regex('failed'),
+            description: 'This incident was created based on the following conditions: failures. See the PE console for the full report. You can access the PE console at test_console.',
           }
           expect_created_incident(expected_incident, expected_credentials)
           processor.process
@@ -289,6 +291,7 @@ describe 'ServiceNow report processor' do
       it 'decrypts the oauth token' do
         expected_incident = {
           short_description: short_description_regex('failed'),
+          description: 'This incident was created based on the following conditions: failures. See the PE console for the full report. You can access the PE console at test_console.',
         }
         expect_created_incident(expected_incident, oauth_token: 'test_token')
         processor.process


### PR DESCRIPTION
This adds a report_labels function which is used to populate the
incident description with report labels that describe why an incident
was created. We decided to leave out the 'always' trigger as it didn't
seem helpful.

The create_incident? method now uses two helper methods,
event_conditions, and satisfied_conditions which don't change any
functionality or ordering, but allow us to only calculate the satisfied
conditions once so that they can be reused by the report_labels
function.