### PR TITLE
(PIE-335) Add configurable facts to incidents

### DIFF
--- a/manifests/event_management.pp
+++ b/manifests/event_management.pp
@@ -12,6 +12,8 @@ class servicenow_reporting_integration::event_management (
   Optional[Integer[0, 5]] $pending_corrective_changes_event_severity  = 2,
   Optional[Integer[0, 5]] $pending_intentional_changes_event_severity = 1,
   Optional[Integer[0, 5]] $no_changes_event_severity                  = 1,
+  Optional[Array[String[1]]] $include_facts                           = ['aio_agent_version', 'id', 'memorysize', 'memoryfree', 'ipaddress', 'ipaddress6', 'os.distro', 'os.windows', 'path', 'uptime', 'rubyversion'],
+  Enum['yaml', 'pretty_json', 'json'] $facts_format                   = 'yaml',
 ) {
   class { 'servicenow_reporting_integration':
     operation_mode                             => 'event_management',
@@ -27,5 +29,7 @@ class servicenow_reporting_integration::event_management (
     pending_corrective_changes_event_severity  => $pending_corrective_changes_event_severity,
     pending_intentional_changes_event_severity => $pending_intentional_changes_event_severity,
     no_changes_event_severity                  => $no_changes_event_severity,
+    include_facts                              => $include_facts,
+    facts_format                               => $facts_format,
   }
 }

--- a/manifests/incident_management.pp
+++ b/manifests/incident_management.pp
@@ -67,6 +67,8 @@ class servicenow_reporting_integration::incident_management (
   Optional[String[1]] $assigned_to                                                           = undef,
   Servicenow_reporting_integration::IncidentCreationConditions $incident_creation_conditions = ['failures', 'corrective_changes'],
   String $servicenow_credentials_validation_table                                            = 'incident',
+  Optional[Array[String[1]]] $include_facts                                                  = ['aio_agent_version', 'id', 'memorysize', 'memoryfree', 'ipaddress', 'ipaddress6', 'os.distro', 'os.windows', 'path', 'uptime', 'rubyversion'],
+  Enum['yaml', 'pretty_json', 'json'] $facts_format                                          = 'yaml',
 ) {
   class { 'servicenow_reporting_integration':
     operation_mode                          => 'incident_management',
@@ -86,5 +88,7 @@ class servicenow_reporting_integration::incident_management (
     assigned_to                             => $assigned_to,
     incident_creation_conditions            => $incident_creation_conditions,
     servicenow_credentials_validation_table => $servicenow_credentials_validation_table,
+    include_facts                           => $include_facts,
+    facts_format                            => $facts_format,
   }
 }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -13,6 +13,8 @@ class servicenow_reporting_integration (
   Optional[String[1]] $oauth_token                                                                     = undef,
   Optional[String] $servicenow_credentials_validation_table                                            = undef,
   Optional[String[1]] $pe_console_url                                                                  = undef,
+  Optional[Array[String[1]]] $include_facts                                                            = ['identity.user', 'ipaddress','memorysize', 'memoryfree', 'os'],
+  Enum['yaml', 'pretty_json', 'json'] $facts_format                                                    = 'pretty_json',
   # PARAMETERS SPECIFIC TO INCIDENT_MANAGEMENT
   Optional[String[1]] $caller_id                                                                       = undef,
   Optional[String[1]] $category                                                                        = undef,
@@ -112,6 +114,8 @@ class servicenow_reporting_integration (
       pending_corrective_changes_event_severity  => $pending_corrective_changes_event_severity,
       pending_intentional_changes_event_severity => $pending_intentional_changes_event_severity,
       no_changes_event_severity                  => $no_changes_event_severity,
+      include_facts                              => $include_facts,
+      facts_format                               => $facts_format,
       }),
     notify       => $settings_file_notify,
   }

--- a/spec/acceptance/reporting/event_spec.rb
+++ b/spec/acceptance/reporting/event_spec.rb
@@ -30,6 +30,9 @@ describe 'ServiceNow reporting: event management' do
     expect(event['description']).to match(%r{Resource Statuses:})
     expect(event['description']).to match(%r{Notify\[foo\]\/message: defined 'message' as 'foo'})
     expect(event['description']).to match(%r{manifests\/site.pp:2})
+    expect(event['description']).to match(%r{== Facts ==})
+    expect(event['description']).to match(%r{id: root})
+    expect(event['description']).to match(%r{os.distro:\s+codename:[\s\S]*description})
     # Check that the PE console URL is included
     expect(event['description']).to match(Regexp.new(Regexp.escape(master.uri)))
   end

--- a/spec/support/unit/reports/servicenow_spec_helpers.rb
+++ b/spec/support/unit/reports/servicenow_spec_helpers.rb
@@ -43,6 +43,8 @@ def default_settings_hash
     'pending_corrective_changes_event_severity'  => 2,
     'pending_intentional_changes_event_severity' => 1,
     'no_changes_event_severity'                  => 5000,
+    'facts_format'                               => 'yaml',
+    'include_facts'                              => ['id', 'os.distro'],
   }
 end
 
@@ -134,4 +136,33 @@ def short_description_regex(status)
   # execute fast enough that race conditions and intermittent failures shouldn't
   # be a problem.
   Regexp.new(%r{Puppet.*#{Regexp.escape(status)}.*#{processor.host} \(report time: #{Time.now.strftime('%F %H:%M')}.*\)})
+end
+
+def default_facts
+  {
+    'id' => 'foo',
+    'ipaddress' => '192.168.0.1',
+    'memorysize' => '7.80 GiB',
+    'memoryfree' => '2.05 GiB',
+    'os' => {
+      'architecture' => 'amd64',
+      'distro' => {
+        'codename' => 'xenial',
+        'description' => 'Ubuntu 16.04.5 LTS',
+        'id' => 'Ubuntu',
+        'release' => {
+          'full' => '16.04',
+          'major' => '16.04',
+        },
+      },
+      'family' => 'Debian',
+      'hardware' => 'x86_64',
+      'name' => 'Ubuntu',
+      'release' => {
+        'full' => '16.04',
+        'major' => '16.04',
+      },
+      'selinux' => { 'enabled' => false },
+    },
+  }
 end

--- a/spec/unit/reports/servicenow/event_spec.rb
+++ b/spec/unit/reports/servicenow/event_spec.rb
@@ -4,9 +4,11 @@ describe 'ServiceNow report processor: event_management mode' do
   let(:processor) { new_processor }
   let(:settings_hash) { default_settings_hash.merge('operation_mode' => 'event_management') }
   let(:expected_credentials) { default_credentials }
+  let(:facts) { default_facts }
 
   before(:each) do
     mock_settings_file(settings_hash)
+    allow(processor).to receive(:facts).and_return(facts)
   end
 
   it 'sends a node_report event' do
@@ -22,6 +24,9 @@ describe 'ServiceNow report processor: event_management mode' do
       expect(actual_event['description']).to match(%r{test_console})
       expect(actual_event['description']).to match(%r{Resource Statuses:\s\/foo\/bar\/message: defined 'message' as 'hello'})
       expect(actual_event['description']).to match(%r{Resource Definition: site.pp:1})
+      expect(actual_event['description']).to match(%r{== Facts ==})
+      expect(actual_event['description']).to match(%r{id: foo})
+      expect(actual_event['description']).to match(%r{os.distro:\s+codename:[\s\S]*description})
       # The message key will be tested more thoroughly in other
       # tests
       expect(actual_event['message_key']).not_to be_empty
@@ -60,6 +65,7 @@ describe 'ServiceNow report processor: event_management mode' do
           before(:each) do
             [processor_one, processor_two].each do |processor|
               allow(processor).to receive(:status).and_return('changed')
+              allow(processor).to receive(:facts).and_return(facts)
               mock_events(processor, new_mock_event(status: 'success', corrective_change: false))
             end
           end
@@ -71,6 +77,7 @@ describe 'ServiceNow report processor: event_management mode' do
           before(:each) do
             [processor_one, processor_two].each do |processor|
               allow(processor).to receive(:status).and_return('changed')
+              allow(processor).to receive(:facts).and_return(facts)
             end
 
             events = [
@@ -90,6 +97,7 @@ describe 'ServiceNow report processor: event_management mode' do
           before(:each) do
             [processor_one, processor_two].each do |processor|
               mock_events(processor, new_mock_event(status: 'failure'))
+              allow(processor).to receive(:facts).and_return(facts)
             end
 
             allow(processor_one).to receive(:status).and_return('failed')
@@ -103,6 +111,7 @@ describe 'ServiceNow report processor: event_management mode' do
           before(:each) do
             [processor_one, processor_two].each do |processor|
               allow(processor).to receive(:status).and_return('changed')
+              allow(processor).to receive(:facts).and_return(facts)
             end
 
             mock_events(processor_one, new_mock_event(status: 'failure'))
@@ -124,6 +133,7 @@ describe 'ServiceNow report processor: event_management mode' do
 
         [processor_one, processor_two].each do |processor|
           mock_events(processor)
+          allow(processor).to receive(:facts).and_return(facts)
         end
       end
 

--- a/spec/unit/reports/servicenow/incident_spec.rb
+++ b/spec/unit/reports/servicenow/incident_spec.rb
@@ -4,9 +4,11 @@ describe 'ServiceNow report processor: incident creation' do
   let(:processor) { new_processor }
   let(:settings_hash) { default_settings_hash }
   let(:expected_credentials) { default_credentials }
+  let(:facts) { default_facts }
 
   before(:each) do
     mock_settings_file(settings_hash)
+    allow(processor).to receive(:facts).and_return(facts)
   end
 
   context 'when incident_creation_conditions is not an array' do

--- a/spec/unit/reports/servicenow/misc_spec.rb
+++ b/spec/unit/reports/servicenow/misc_spec.rb
@@ -6,9 +6,11 @@ describe 'ServiceNow report processor: miscellaneous tests' do
   let(:processor) { new_processor }
   let(:settings_hash) { default_settings_hash }
   let(:expected_credentials) { default_credentials }
+  let(:facts) { default_facts }
 
   before(:each) do
     mock_settings_file(settings_hash)
+    allow(processor).to receive(:facts).and_return(facts)
   end
 
   context 'loading ServiceNow config' do

--- a/templates/servicenow_reporting.yaml.epp
+++ b/templates/servicenow_reporting.yaml.epp
@@ -20,6 +20,8 @@
       Optional[Integer[0, 5]] $pending_corrective_changes_event_severity,
       Optional[Integer[0, 5]] $pending_intentional_changes_event_severity,
       Optional[Integer[0, 5]] $no_changes_event_severity,
+      Array[String] $include_facts,
+      String $facts_format,
       # Extra variables that _aren't_ part of the servicenow_reporting_integration
       # class' parameters go here
       String $report_processor_version,
@@ -48,4 +50,6 @@ intentional_changes_event_severity: <%= $intentional_changes_event_severity %>
 pending_corrective_changes_event_severity: <%= $pending_corrective_changes_event_severity %>
 pending_intentional_changes_event_severity: <%= $pending_intentional_changes_event_severity %>
 no_changes_event_severity: <%= $no_changes_event_severity %>
+include_facts: <%= $include_facts %>
+facts_format: <%= $facts_format %>
 report_processor_version: <%= $report_processor_version %>


### PR DESCRIPTION
This change allows users to specify a set of facts that should be
included with every incident that is created.

An example of the description this change would generate based on the
following selected facts is below:
`['identity.user', 'ipaddress','memorysize', 'memoryfree', 'os']`

These facts demonstrate what included facts look like for nested facts
queries, top level facts, and complex facts.

```
This incident was created based on the following conditions: intentional_changes. See the PE console for the full report. You can access the PE console at https://inept-fieldwork.delivery.puppetlabs.net.

facts:

identity.user: "root"
ipaddress: "10.16.112.18"
memorysize: "7.80 GiB"
memoryfree: "2.50 GiB"
os: {
  "architecture": "amd64",
  "distro": {
    "codename": "xenial",
    "description": "Ubuntu 16.04.5 LTS",
    "id": "Ubuntu",
    "release": {
      "full": "16.04",
      "major": "16.04"
    }
  },
  "family": "Debian",
  "hardware": "x86_64",
  "name": "Ubuntu",
  "release": {
    "full": "16.04",
    "major": "16.04"
  },
  "selinux": {
    "enabled": false
  }
}
```