### PR TITLE
(PIE-335) Populate Node Field For Events

### DIFF
--- a/lib/puppet/reports/servicenow.rb
+++ b/lib/puppet/reports/servicenow.rb
@@ -25,6 +25,7 @@ Puppet::Reports.register_report(:servicenow) do
       'type'     => 'node_report',
       # 5 => 'OK' severity
       'severity' => '5',
+      'node'     => host,
     }
 
     # Compute the message key hash, which contains all relevant information

--- a/spec/acceptance/reporting/event_spec.rb
+++ b/spec/acceptance/reporting/event_spec.rb
@@ -24,5 +24,6 @@ describe 'ServiceNow reporting: event management' do
     expect(event['type']).to eql('node_report')
     expect(event['severity']).to eql('5')
     expect(event['message_key']).not_to be_empty
+    expect(event['node']).not_to be_empty
   end
 end

--- a/spec/unit/reports/servicenow/event_spec.rb
+++ b/spec/unit/reports/servicenow/event_spec.rb
@@ -11,12 +11,14 @@ describe 'ServiceNow report processor: event_management mode' do
 
   it 'sends a node_report event' do
     allow(processor).to receive(:status).and_return 'changed'
+    allow(processor).to receive(:host).and_return 'fqdn'
     mock_event_as_resource_status(processor, 'success', false)
 
     expect_sent_event(expected_credentials) do |actual_event|
       expect(actual_event['source']).to eql('Puppet')
       expect(actual_event['type']).to eql('node_report')
       expect(actual_event['severity']).to eql('5')
+      expect(actual_event['node']).to eql('fqdn')
       # The message key will be tested more thoroughly in other
       # tests
       expect(actual_event['message_key']).not_to be_empty


### PR DESCRIPTION
The node field tells Servicenow which node an event relates to.

Without it correlation rules and grouping rules won't work very well.