### PR TITLE
(PIE-348) Add ignore OK events rule task

### DIFF
--- a/files/add_ignore_event_ok_rule_data.erb
+++ b/files/add_ignore_event_ok_rule_data.erb
@@ -1,0 +1,22 @@
+{
+  "bind": false,
+  "rule_version": "jakarta",
+  "close_alert_int": "120",
+  "event_class": "Puppet",
+  "event_data": "<%= event_data %>",
+  "order": "<%= order %>",
+  "threshold": "false",
+  "description": "<%= description %>",
+  "bind_type": "2",
+  "ci_type": "cmdb_ci",
+  "filter": "typeSTARTSWITHnode_report^severity=5^EQ",
+  "simple_filter": "<%= simple_filter %>",
+  "active": "true",
+  "name": "<%= name %>",
+  "create_alert_int": "120",
+  "close_alert_freq": "1",
+  "ignore_event": "true",
+  "create_alert_freq": "1",
+  "additional_info_filter": "{\"conditions\":[]}",
+  "rule_mapping_counter": "0"
+}

--- a/files/event_data.json
+++ b/files/event_data.json
@@ -1,0 +1,103 @@
+{
+  "additionalInfoFields": [],
+  "hasChanged": true,
+  "expressions": [],
+  "rawFields": [
+    {
+      "mapping": [],
+      "regex": "",
+      "simpleMode": "",
+      "label": "Description",
+      "name": "description",
+      "value": ""
+    },
+    {
+      "mapping": [],
+      "regex": "",
+      "simpleMode": "",
+      "label": "Node",
+      "name": "node",
+      "value": "milder-whiskey.delivery.puppetlabs.net"
+    },
+    {
+      "mapping": [],
+      "regex": "",
+      "simpleMode": "",
+      "label": "Type",
+      "name": "type",
+      "value": "node_report"
+    },
+    {
+      "mapping": [],
+      "regex": "",
+      "simpleMode": "",
+      "label": "Resource",
+      "name": "resource",
+      "value": ""
+    },
+    {
+      "mapping": [],
+      "regex": "",
+      "simpleMode": "",
+      "label": "Message key",
+      "name": "message_key",
+      "value": "2891d082e5af0c2401f85b1d5b73598dfea654f8"
+    },
+    {
+      "mapping": [],
+      "regex": "",
+      "simpleMode": "",
+      "label": "Severity",
+      "name": "severity",
+      "value": "5"
+    },
+    {
+      "mapping": [],
+      "regex": "",
+      "simpleMode": "",
+      "label": "Metric Name",
+      "name": "metric_name",
+      "value": ""
+    },
+    {
+      "mapping": [],
+      "regex": "",
+      "simpleMode": "",
+      "label": "Source instance",
+      "name": "event_class",
+      "value": ""
+    },
+    {
+      "mapping": [],
+      "regex": "",
+      "simpleMode": "",
+      "label": "Source",
+      "name": "source",
+      "value": "Puppet"
+    },
+    {
+      "mapping": [],
+      "regex": "",
+      "simpleMode": "",
+      "label": "Resolution state",
+      "name": "resolution_state",
+      "value": "New"
+    },
+    {
+      "mapping": [],
+      "regex": "",
+      "simpleMode": "",
+      "label": "CI type",
+      "name": "ci_type",
+      "value": ""
+    },
+    {
+      "mapping": [],
+      "regex": "",
+      "simpleMode": "",
+      "label": "Classification",
+      "name": "classification",
+      "value": "0"
+    }
+  ]
+}

--- a/files/ok_rule_simple_filter.json
+++ b/files/ok_rule_simple_filter.json
@@ -1,0 +1,45 @@
+{
+  "compound_type": "or",
+  "subpredicates": [
+    {
+      "compound_type": "and",
+      "subpredicates": [
+        {
+          "subpredicates": [
+            {
+              "field": {
+                "choices": [],
+                "label": "Type",
+                "name": "type",
+                "value": "node_report"
+              },
+              "operator": {
+                "advancedEditor": "string",
+                "editor": "string",
+                "label": "starts with",
+                "name": "STARTSWITH"
+              },
+              "fieldType": "string"
+            },
+            {
+              "field": {
+                "choices": [],
+                "label": "Severity",
+                "name": "severity",
+                "value": "5"
+              },
+              "operator": {
+                "advancedEditor": "choice",
+                "editor": "field",
+                "label": "is",
+                "name": "="
+              },
+              "fieldType": "choice"
+            }
+          ],
+          "compound_type": "and"
+        }
+      ]
+    }
+  ]
+}

--- a/metadata.json
+++ b/metadata.json
@@ -11,6 +11,10 @@
     {
       "name": "puppetlabs/inifile",
       "version_requirement": ">= 1.0.0 < 5.0.0"
+    },
+    {
+      "name": "puppetlabs/ruby_task_helper",
+      "version_requirement": ">= 0.3.0 <= 2.0.0"
     }
   ],
   "operatingsystem_support": [

--- a/tasks/add_ignore_ok_events_rule.json
+++ b/tasks/add_ignore_ok_events_rule.json
@@ -1,0 +1,48 @@
+{
+    "puppet_task_version": 1,
+    "supports_noop": false,
+    "description": "Add an event rule that will ignore Puppet events with OK status to prevent creating alerts for them.",
+    "remote": true,
+    "parameters": {
+        "name": {
+            "description": "The name of the rule to create. Defaults to 'Puppet Node Report - Info'",
+            "type": "Optional[String]",
+            "default": "Puppet Node Report - Info"
+        },
+        "description": {
+            "description": "Description to add to the rule.",
+            "type": "Optional[String]",
+            "default": "Node reports with severity level 'Ok'."
+        },
+        "order": {
+            "description": "Order of rule application. Defaults to 100.",
+            "type": "Optional[Integer]",
+            "default": 100
+        },
+        "user": {
+            "description": "Username authorized to insert event rules.",
+            "type": "Optional[String]"
+        },
+        "password": {
+            "description": "ServiceNow password",
+            "type": "Optional[String]",
+            "sensitive": true
+        },
+        "instance": {
+            "description": "ServiceNow instance. For example, dev84270.service-now.com.",
+            "type": "Optional[String]"
+        },
+        "oauth_token": {
+            "description": "ServiceNow OAuth token",
+            "type": "Optional[String]",
+            "sensitive": true
+        }
+    },
+    "files": [
+        "ruby_task_helper/files/task_helper.rb",
+        "servicenow_reporting_integration/lib/puppet/util/servicenow.rb",
+        "servicenow_reporting_integration/files/ok_rule_simple_filter.json",
+        "servicenow_reporting_integration/files/event_data.json",
+        "servicenow_reporting_integration/files/add_ignore_event_ok_rule_data.erb"
+    ]
+}

--- a/tasks/add_ignore_ok_events_rule.rb
+++ b/tasks/add_ignore_ok_events_rule.rb
@@ -1,0 +1,54 @@
+#!/opt/puppetlabs/puppet/bin/ruby
+
+# rubocop:disable Lint/UnderscorePrefixedVariableName
+
+require_relative '../../ruby_task_helper/files/task_helper.rb'
+require_relative '../lib/puppet/util/servicenow.rb'
+require 'erb'
+
+# This task creates an event rule in Servicenow
+class ServiceNowEventRuleCreate < TaskHelper
+  def task(name: 'Puppet Node Report - Info',
+           description: 'Node reports with severity level \'Ok\'.',
+           order: 100,
+           user: nil,
+           password: nil,
+           instance: nil,
+           oauth_token: nil,
+           _target: nil,
+           **_kwargs)
+
+    simple_filter = File.read(File.join(__dir__, '../files/ok_rule_simple_filter.json')).gsub('"', '\"').gsub(%r{\s+}, '')
+    event_data = File.read(File.join(__dir__, '../files/event_data.json')).gsub('"', '\"').gsub(%r{\s+}, '')
+
+    # The two variables above 'simple_filter' and 'event_data' are both available inside the erb template function
+    # because the current scope binding is passed into the ERB call.
+    data = ERB.new(File.read(File.join(__dir__, '../files/add_ignore_event_ok_rule_data.erb'))).result binding
+
+    user        = _target[:user]        if user.nil?
+    password    = _target[:password]    if password.nil?
+    oauth_token = _target[:oauth_token] if oauth_token.nil?
+    instance    = _target[:uri]         if instance.nil?
+
+    uri = "https://#{instance}/api/now/table/em_match_rule"
+
+    begin
+      response = Puppet::Util::Servicenow.do_snow_request(uri,
+                                                          'POST',
+                                                          JSON.parse(data),
+                                                          user: user,
+                                                          password: password,
+                                                          oauth_token: oauth_token)
+
+      raise "Failed to create the rule. Error from #{uri} (status: #{response.code}): #{response.body}" if response.code.to_i >= 300
+    rescue => exception
+      raise TaskHelper::Error.new('Servicenow Request Error',
+                                  'EventRuleCreate/do_snow_request',
+                                  exception)
+    end
+  end
+end
+
+if $PROGRAM_NAME == __FILE__
+  ServiceNowEventRuleCreate.run
+end


### PR DESCRIPTION
This change adds a task to the module that will add an event rule to
ignore events with a severity level of 'OK'. These events should
simply represent Puppet runs where nothing happened.

If anything like changes or failures happened, those should events
should have a different severity level that can be targeted with
different rules for how to create alerts for them.