### PR TITLE
(PIE-343) Add Resource Names To Description

### DIFF
--- a/lib/puppet/reports/servicenow.rb
+++ b/lib/puppet/reports/servicenow.rb
@@ -29,7 +29,7 @@ Puppet::Reports.register_report(:servicenow) do
       # Source Instance is sent as event_class in the api
       # PuppetDB uses Puppet[:node_name_value] to determine the server name so this should be fine.
       'event_class' => Puppet[:node_name_value],
-      'description' => report_description(settings_hash),
+      'description' => report_description(settings_hash, resource_statuses),
     }
 
     # Compute the message key hash, which contains all relevant information
@@ -83,7 +83,7 @@ Puppet::Reports.register_report(:servicenow) do
     short_description_status = noop_pending ? 'pending changes' : status
     incident_data = {
       short_description: "Puppet run report (status: #{short_description_status}) for node #{host} (report time: #{format_report_timestamp(time, metrics)})",
-      description: report_description(settings_hash),
+      description: report_description(settings_hash, resource_statuses),
       caller_id: settings_hash['caller_id'],
       category: settings_hash['category'],
       subcategory: settings_hash['subcategory'],

--- a/spec/acceptance/reporting/event_spec.rb
+++ b/spec/acceptance/reporting/event_spec.rb
@@ -26,6 +26,10 @@ describe 'ServiceNow reporting: event management' do
     expect(event['message_key']).not_to be_empty
     expect(event['node']).not_to be_empty
     expect(event['event_class']).to match(Regexp.new(Regexp.escape(master.uri)))
+    expect(event['description']).to match(Regexp.new(Regexp.escape(master.uri)))
+    expect(event['description']).to match(%r{Resource Statuses:})
+    expect(event['description']).to match(%r{Notify\[foo\]\/message: defined 'message' as 'foo'})
+    expect(event['description']).to match(%r{manifests\/site.pp:2})
     # Check that the PE console URL is included
     expect(event['description']).to match(Regexp.new(Regexp.escape(master.uri)))
   end

--- a/spec/acceptance/reporting/incident_spec.rb
+++ b/spec/acceptance/reporting/incident_spec.rb
@@ -108,7 +108,21 @@ describe 'ServiceNow reporting: incident creation' do
 
         include_context 'corrective change setup', cc_resource_hash
         include_context 'incident query setup'
-        include_examples 'incident creation test', 'changed'
+        include_examples 'incident creation test', 'changed' do
+          let(:additional_incident_assertions) do
+            # Testing to ensure that two resource statuses made it into the
+            # description
+            ->(incident) {
+              # The header should only be in there once.
+              header_count = incident['description'].scan(%r{Resource Statuses:}).size
+              expect(header_count).to be(1)
+              expect(incident['description']).to match(%r{File\[\/tmp\/corrective_change\]\/content:})
+              expect(incident['description']).to match(%r{site.pp:2})
+              expect(incident['description']).to match(%r{Notify\[foo_intentional_change\]\/message:})
+              expect(incident['description']).to match(%r{site.pp:6})
+            }
+          end
+        end
       end
     end
   end

--- a/spec/spec_helper_acceptance_local.rb
+++ b/spec/spec_helper_acceptance_local.rb
@@ -93,3 +93,9 @@ def get_metadata_json
   raw_metadata_json = master.run_shell("cat #{METADATA_JSON_PATH}").stdout.chomp
   JSON.parse(raw_metadata_json)
 end
+
+def resource_title_regex(resource_hash)
+  type = resource_hash['type'].capitalize
+  title = resource_hash['title']
+  %r{#{"#{type}\\[#{title}\\]"}}
+end

--- a/spec/support/unit/reports/servicenow_spec_helpers.rb
+++ b/spec/support/unit/reports/servicenow_spec_helpers.rb
@@ -59,22 +59,29 @@ def new_mock_response(status, body)
 end
 
 def new_mock_event(event_fields = {})
+  event_fields[:property] = 'message'
+  event_fields[:message]  = 'defined \'message\' as \'hello\''
   Puppet::Transaction::Event.new(event_fields)
 end
 
-def new_mock_resource_status(events)
+def new_mock_resource_status(events, status_changed, status_failed)
   status = instance_double('resource status')
   allow(status).to receive(:events).and_return(events)
+  allow(status).to receive(:out_of_sync).and_return(status_changed)
+  allow(status).to receive(:failed).and_return(status_failed)
+  allow(status).to receive(:containment_path).and_return(['foo', 'bar'])
+  allow(status).to receive(:file).and_return('site.pp')
+  allow(status).to receive(:line).and_return(1)
   status
 end
 
 def mock_events(processor, *events)
-  allow(processor).to receive(:resource_statuses).and_return('mock_resource' => new_mock_resource_status(events))
+  allow(processor).to receive(:resource_statuses).and_return('mock_resource' => new_mock_resource_status(events, true, false))
 end
 
-def mock_event_as_resource_status(processor, event_status, event_corrective_change)
+def mock_event_as_resource_status(processor, event_status, event_corrective_change, status_changed = true, status_failed = false)
   mock_events = [new_mock_event(status: event_status, corrective_change: event_corrective_change)]
-  mock_resource_status = new_mock_resource_status(mock_events)
+  mock_resource_status = new_mock_resource_status(mock_events, status_changed, status_failed)
   allow(processor).to receive(:resource_statuses).and_return('mock_resource' => mock_resource_status)
 end
 

--- a/spec/unit/reports/servicenow/event_spec.rb
+++ b/spec/unit/reports/servicenow/event_spec.rb
@@ -19,6 +19,29 @@ describe 'ServiceNow report processor: event_management mode' do
       expect(actual_event['type']).to eql('node_report')
       expect(actual_event['severity']).to eql('5')
       expect(actual_event['node']).to eql('fqdn')
+      expect(actual_event['description']).to match(%r{test_console})
+      expect(actual_event['description']).to match(%r{Resource Statuses:\s\/foo\/bar\/message: defined 'message' as 'hello'})
+      expect(actual_event['description']).to match(%r{Resource Definition: site.pp:1})
+      # The message key will be tested more thoroughly in other
+      # tests
+      expect(actual_event['message_key']).not_to be_empty
+    end
+
+    processor.process
+  end
+
+  it 'sends a node_report with no resource events' do
+    allow(processor).to receive(:status).and_return 'changed'
+    allow(processor).to receive(:host).and_return 'fqdn'
+    mock_event_as_resource_status(processor, 'success', false, false)
+
+    expect_sent_event(expected_credentials) do |actual_event|
+      expect(actual_event['source']).to eql('Puppet')
+      expect(actual_event['type']).to eql('node_report')
+      expect(actual_event['severity']).to eql('5')
+      expect(actual_event['node']).to eql('fqdn')
+      expect(actual_event['description']).to match(%r{test_console})
+      expect(actual_event['description']).not_to match(%r{Resource Statuses:})
       # The message key will be tested more thoroughly in other
       # tests
       expect(actual_event['message_key']).not_to be_empty


### PR DESCRIPTION
This change adds a function to get a human readable summary of the
changes or failures that have occurred in a Puppet run.

Getting the machine readable version to add to Additional Data will
probably be done by a different function.