### PR TITLE
(PIE-325) Relax version requirements for some dependencies

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -8,7 +8,7 @@ fixtures:
       ref: "0.5.1"
     inifile:
       repo: "puppetlabs/inifile"
-      ref: "4.2.0"
+      ref: "1.0.0"
   repositories:
     "stdlib":
       "repo": "git://github.com/puppetlabs/puppetlabs-stdlib.git"

--- a/metadata.json
+++ b/metadata.json
@@ -10,7 +10,7 @@
   "dependencies": [
     {
       "name": "puppetlabs/inifile",
-      "version_requirement": ">= 4.2.0 <= 4.3.0"
+      "version_requirement": ">= 1.0.0 < 5.0.0"
     }
   ],
   "operatingsystem_support": [


### PR DESCRIPTION
inifile:
  1.0.0 is the first released version of the module on the Forge. We
also extend the upper bound to 5.0.0 since that is also likely to
contain a breaking change.

Signed-off-by: Enis Inan <enis.inan@puppet.com>