### PR TITLE
(PIE-349) Split out event + incident management into separate classes

### DIFF
--- a/manifests/event_management.pp
+++ b/manifests/event_management.pp
@@ -1,0 +1,19 @@
+# TODO: Properly document this class
+class servicenow_reporting_integration::event_management (
+  String[1] $instance,
+  Optional[String[1]] $user                                                                  = undef,
+  Optional[String[1]] $password                                                              = undef,
+  Optional[String[1]] $oauth_token                                                           = undef,
+  Optional[String[1]] $pe_console_url                                                        = undef,
+  String $servicenow_credentials_validation_table                                            = 'em_event',
+) {
+  class { 'servicenow_reporting_integration':
+    operation_mode                          => 'event_management',
+    instance                                => $instance,
+    user                                    => $user,
+    password                                => $password,
+    oauth_token                             => $oauth_token,
+    pe_console_url                          => $pe_console_url,
+    servicenow_credentials_validation_table => $servicenow_credentials_validation_table,
+  }
+}

--- a/manifests/incident_management.pp
+++ b/manifests/incident_management.pp
@@ -1,0 +1,90 @@
+# TODO: Properly document this class
+#
+# @summary Configures the servicenow
+#
+# @example
+#   include servicenow_reporting_integration::incident_management
+# @param [String[1]] instance
+#   The FQDN of the ServiceNow instance
+# @param [String[1]] pe_console_url
+#   The PE console url
+# @param [String[1]] caller_id
+#  The sys_id of the incident's caller as specified in the sys_user table
+# @param [String] servicenow_credentials_validation_table
+#  The table to read for validating the provided ServiceNow credentials.
+#  You should set this to another table if the current set of credentials
+#  don't have READ access to the default 'incident' table. Note that you
+#  can turn the ServiceNow credentials validation off by setting this
+#  parameter to the empty string ''.
+# @param [String] user
+#  The username of the account with permission to query data
+# @param [String] password
+#  The password of the account used to query data from Servicenow
+# @param [String] oauth_token
+#  An OAuth access token created in Servicenow that can be used in place of a
+#  username and password.
+# @param [Optional[String[1]]] category
+#  The incident's category
+# @param [Optional[String[1]]] subcategory
+#  The incident's subcategory
+# @param [Optional[String[1]]] contact_type
+#  The incident's contact type
+# @param[Optional[Integer]] state
+#  The incident's state
+# @param[Optional[Integer]] impact
+#  The incident's impact
+# @param[Optional[Integer]] urgency
+#  The incident's urgency
+# @param [Optional[String[1]]] assignment_group
+#  The sys_id of the incident's assignment group as specified in the
+#  sys_user_group table
+# @param [Optional[String[1]]] assigned_to
+#  The sys_id of the user assigned to the incident as specified in the
+#  sys_user table. Note that if assignment_group is also specified, then
+#  this must correspond to a user who is a member of the assignment_group.
+# @param [Servicenow_reporting_integration::IncidentCreationConditions] incident_creation_conditions
+#  The incident creation conditions. The report processor will create incidents for reports
+#  that satisfy at least one of the specified conditions. For example, if you use the default
+#  value (`['failures', 'corrective_changes']`), then the report processor will create an
+#  incident if the report had any failures _or_ corrective changes.
+#
+#  Note: Set this parameter to `['never']` if you want to completely turn off incident creation.
+#  If set to `['never']`, then this module will not create any incidents at all.
+class servicenow_reporting_integration::incident_management (
+  String[1] $instance,
+  String[1] $caller_id,
+  Optional[String[1]] $user                                                                  = undef,
+  Optional[String[1]] $password                                                              = undef,
+  Optional[String[1]] $oauth_token                                                           = undef,
+  Optional[String[1]] $pe_console_url                                                        = undef,
+  Optional[String[1]] $category                                                              = undef,
+  Optional[String[1]] $subcategory                                                           = undef,
+  Optional[String[1]] $contact_type                                                          = undef,
+  Optional[Integer] $state                                                                   = undef,
+  Optional[Integer] $impact                                                                  = undef,
+  Optional[Integer] $urgency                                                                 = undef,
+  Optional[String[1]] $assignment_group                                                      = undef,
+  Optional[String[1]] $assigned_to                                                           = undef,
+  Servicenow_reporting_integration::IncidentCreationConditions $incident_creation_conditions = ['failures', 'corrective_changes'],
+  String $servicenow_credentials_validation_table                                            = 'incident',
+) {
+  class { 'servicenow_reporting_integration':
+    operation_mode                          => 'incident_management',
+    instance                                => $instance,
+    caller_id                               => $caller_id,
+    user                                    => $user,
+    password                                => $password,
+    oauth_token                             => $oauth_token,
+    pe_console_url                          => $pe_console_url,
+    category                                => $category,
+    subcategory                             => $subcategory,
+    contact_type                            => $contact_type,
+    state                                   => $state,
+    impact                                  => $impact,
+    urgency                                 => $urgency,
+    assignment_group                        => $assignment_group,
+    assigned_to                             => $assigned_to,
+    incident_creation_conditions            => $incident_creation_conditions,
+    servicenow_credentials_validation_table => $servicenow_credentials_validation_table,
+  }
+}

--- a/spec/acceptance/reporting/event_spec.rb
+++ b/spec/acceptance/reporting/event_spec.rb
@@ -11,7 +11,7 @@ describe 'ServiceNow reporting: event management' do
     }
   end
   let(:setup_manifest) do
-    to_manifest(declare('Service', 'pe-puppetserver'), declare('class', 'servicenow_reporting_integration', params))
+    to_manifest(declare('Service', 'pe-puppetserver'), declare('class', 'servicenow_reporting_integration::event_management', params))
   end
 
   include_context 'event query setup'

--- a/spec/acceptance/reporting/incident_spec.rb
+++ b/spec/acceptance/reporting/incident_spec.rb
@@ -26,7 +26,6 @@ describe 'ServiceNow reporting: incident creation' do
 
     {
       instance: servicenow_instance.uri,
-      operation_mode: 'incident_management',
       pe_console_url: "https://#{master.uri}",
       caller_id: kaller['sys_id'],
       user: servicenow_config['user'],
@@ -34,7 +33,7 @@ describe 'ServiceNow reporting: incident creation' do
     }
   end
   let(:setup_manifest) do
-    to_manifest(declare('Service', 'pe-puppetserver'), declare('class', 'servicenow_reporting_integration', params))
+    to_manifest(declare('Service', 'pe-puppetserver'), declare('class', 'servicenow_reporting_integration::incident_management', params))
   end
   let(:sitepp_content) do
     # This is test-specific

--- a/spec/acceptance/reporting/misc_spec.rb
+++ b/spec/acceptance/reporting/misc_spec.rb
@@ -12,7 +12,6 @@ describe 'ServiceNow reporting: miscellaneous tests' do
 
     {
       instance: servicenow_instance.uri,
-      operation_mode: 'incident_management',
       pe_console_url: "https://#{master.uri}",
       caller_id: kaller['sys_id'],
       user: servicenow_config['user'],
@@ -20,7 +19,7 @@ describe 'ServiceNow reporting: miscellaneous tests' do
     }
   end
   let(:setup_manifest) do
-    to_manifest(declare('Service', 'pe-puppetserver'), declare('class', 'servicenow_reporting_integration', params))
+    to_manifest(declare('Service', 'pe-puppetserver'), declare('class', 'servicenow_reporting_integration::incident_management', params))
   end
   let(:sitepp_content) do
     # This is test-specific

--- a/spec/classes/event_management_spec.rb
+++ b/spec/classes/event_management_spec.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'securerandom'
+require 'support/classes/shared_contexts'
+require 'support/classes/shared_examples'
+
+describe 'servicenow_reporting_integration::event_management' do
+  include_context 'common reporting integration setup'
+
+  let(:params) do
+    {
+      'instance'       => 'foo_instance',
+      'pe_console_url' => 'foo_pe_console_url',
+      'user'           => 'foo_user',
+      'password'       => 'foo_password',
+    }
+  end
+
+  it { is_expected.to compile }
+
+  include_examples 'common reporting integration tests', operation_mode: 'event_management'
+end

--- a/spec/classes/incident_management_spec.rb
+++ b/spec/classes/incident_management_spec.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'securerandom'
+require 'support/classes/shared_contexts'
+require 'support/classes/shared_examples'
+
+describe 'servicenow_reporting_integration::incident_management' do
+  include_context 'common reporting integration setup'
+
+  let(:params) do
+    {
+      'instance'       => 'foo_instance',
+      'pe_console_url' => 'foo_pe_console_url',
+      'user'           => 'foo_user',
+      'password'       => 'foo_password',
+      'caller_id'      => 'foo_caller_id',
+    }
+  end
+
+  context 'without the required parameters' do
+    let(:params) do
+      p = super()
+      p.delete('caller_id')
+      p
+    end
+
+    it { is_expected.to compile.and_raise_error(%r{caller_id}) }
+  end
+
+  context 'without the optional parameters' do
+    it { is_expected.to compile }
+  end
+
+  context 'with the optional parameters' do
+    let(:params) do
+      # ps => params
+      ps = super()
+
+      ps['category'] = 'foo_category'
+      ps['subcategory'] = 'foo_subcategory'
+      ps['contact_type'] = 'foo_contact_type'
+      ps['state'] = 1
+      ps['impact'] = 1
+      ps['urgency'] = 1
+      ps['assignment_group'] = 'foo_assignment_group'
+      ps['assigned_to'] = 'foo_assigned_to'
+
+      ps
+    end
+
+    it { is_expected.to compile }
+  end
+
+  include_examples 'common reporting integration tests', operation_mode: 'incident_management'
+end

--- a/spec/support/classes/shared_contexts.rb
+++ b/spec/support/classes/shared_contexts.rb
@@ -1,0 +1,19 @@
+RSpec.shared_context 'common reporting integration setup' do
+  let(:pre_condition) do
+    <<-MANIFEST
+    service { 'pe-puppetserver':
+    }
+    MANIFEST
+  end
+  let(:settings_file_path) { Puppet[:confdir] + '/servicenow_reporting.yaml' }
+  # rspec-puppet caches the catalog in each test based on the params/facts.
+  # However, some of the tests reuse the same params (like the report processor
+  # tests). Thus to clear the cache, we have to reset the facts since the params
+  # don't change.
+  let(:facts) do
+    # This is enough to reset the cache
+    {
+      '_cache_reset_' => SecureRandom.uuid,
+    }
+  end
+end

--- a/templates/servicenow_reporting.yaml.epp
+++ b/templates/servicenow_reporting.yaml.epp
@@ -13,7 +13,7 @@
       Optional[Integer] $urgency,
       Optional[String] $assignment_group,
       Optional[String] $assigned_to,
-      Array[String]$incident_creation_conditions,
+      Optional[Array[String]] $incident_creation_conditions,
       # Extra variables that _aren't_ part of the servicenow_reporting_integration
       # class' parameters go here
       String $report_processor_version,


### PR DESCRIPTION
The servicenow_reporting_integration::{incident,event}_management
classes will be how users will use the module. If they want event
management, they will declare
servicenow_reporting_integration::event_management. Otherwise, they can
declare the incident_management class. Note that declaring both classes
leads to undefined behavior (and doesn't make sense).

Signed-off-by: Enis Inan <enis.inan@puppet.com>