### PR TITLE
(PIE-345) Send the puppet server fqdn in the event Source Instance.

### DIFF
--- a/lib/puppet/reports/servicenow.rb
+++ b/lib/puppet/reports/servicenow.rb
@@ -21,11 +21,14 @@ Puppet::Reports.register_report(:servicenow) do
 
   def process_event_management(settings_hash)
     event_data = {
-      'source'   => 'Puppet',
-      'type'     => 'node_report',
-      # 5 => 'OK' severity
-      'severity' => '5',
-      'node'     => host,
+      'source'      => 'Puppet',
+      'type'        => 'node_report',
+      # 5           => 'OK' severity
+      'severity'    => '5',
+      'node'        => host,
+      # Source Instance is sent as event_class in the api
+      # PuppetDB uses Puppet[:node_name_value] to determine the server name so this should be fine.
+      'event_class' => Puppet[:node_name_value],
     }
 
     # Compute the message key hash, which contains all relevant information

--- a/spec/acceptance/reporting/event_spec.rb
+++ b/spec/acceptance/reporting/event_spec.rb
@@ -25,5 +25,6 @@ describe 'ServiceNow reporting: event management' do
     expect(event['severity']).to eql('5')
     expect(event['message_key']).not_to be_empty
     expect(event['node']).not_to be_empty
+    expect(event['event_class']).to match(Regexp.new(Regexp.escape(master.uri)))
   end
 end


### PR DESCRIPTION
Note: When sending the source instance via the event api it is called
event_class. We use the master_used field from the report to indicate
the fqdn of the puppet server the event originated from.