### PR TITLE
(PIE-350) Standardize incident + event descriptions

### DIFF
--- a/lib/puppet/reports/servicenow.rb
+++ b/lib/puppet/reports/servicenow.rb
@@ -29,6 +29,7 @@ Puppet::Reports.register_report(:servicenow) do
       # Source Instance is sent as event_class in the api
       # PuppetDB uses Puppet[:node_name_value] to determine the server name so this should be fine.
       'event_class' => Puppet[:node_name_value],
+      'description' => report_description(settings_hash),
     }
 
     # Compute the message key hash, which contains all relevant information
@@ -82,10 +83,7 @@ Puppet::Reports.register_report(:servicenow) do
     short_description_status = noop_pending ? 'pending changes' : status
     incident_data = {
       short_description: "Puppet run report (status: #{short_description_status}) for node #{host} (report time: #{format_report_timestamp(time, metrics)})",
-      # Ideally, we'd like to link to the specific report here. However, fine-grained PE console links are
-      # unstable even for Y PE releases (e.g. the link is different for PE 2019.2 and PE 2019.8). Thus, the
-      # best and most stable solution we can do (for now) is the description you see here.
-      description: incident_description(satisfied_conditions, settings_hash),
+      description: report_description(settings_hash),
       caller_id: settings_hash['caller_id'],
       category: settings_hash['category'],
       subcategory: settings_hash['subcategory'],

--- a/lib/puppet/util/servicenow.rb
+++ b/lib/puppet/util/servicenow.rb
@@ -151,12 +151,13 @@ module Puppet::Util::Servicenow
   end
   module_function :calculate_satisfied_conditions
 
-  def incident_description(satisfied_conditions, settings_hash)
-    'This incident was created based on the following conditions: '\
-    "#{satisfied_conditions.join(', ')}. See the PE console for the full report. "\
-    "You can access the PE console at #{settings_hash['pe_console_url']}."
+  def report_description(settings_hash)
+    # Ideally, we'd like to link to the specific report here. However, fine-grained PE console links are
+    # unstable even for Y PE releases (e.g. the link is different for PE 2019.2 and PE 2019.8). Thus, the
+    # best and most stable solution we can do (for now) is the description you see here.
+    "See the PE console for the full report. You can access the PE console at #{settings_hash['pe_console_url']}."
   end
-  module_function :incident_description
+  module_function :report_description
 
   def format_report_timestamp(time, metrics)
     total_time = time + metrics['time']['total']

--- a/spec/acceptance/reporting/event_spec.rb
+++ b/spec/acceptance/reporting/event_spec.rb
@@ -26,5 +26,7 @@ describe 'ServiceNow reporting: event management' do
     expect(event['message_key']).not_to be_empty
     expect(event['node']).not_to be_empty
     expect(event['event_class']).to match(Regexp.new(Regexp.escape(master.uri)))
+    # Check that the PE console URL is included
+    expect(event['description']).to match(Regexp.new(Regexp.escape(master.uri)))
   end
 end

--- a/spec/support/unit/reports/shared_examples.rb
+++ b/spec/support/unit/reports/shared_examples.rb
@@ -16,7 +16,7 @@ RSpec.shared_examples 'incident creation test' do |report_status|
                                    raise "invalid report_status #{report_status}. Valid report statuses are 'noop_pending', 'changed', 'failed'"
                                  end
 
-    expected_description = %r{#{settings_hash['incident_creation_conditions'].join(', ')}.*#{settings_hash['pe_console_url']}}
+    expected_description = %r{#{settings_hash['pe_console_url']}}
 
     expected_incident = {
       short_description: expected_short_description,

--- a/spec/unit/reports/servicenow/misc_spec.rb
+++ b/spec/unit/reports/servicenow/misc_spec.rb
@@ -65,7 +65,7 @@ describe 'ServiceNow report processor: miscellaneous tests' do
         it 'decrypts the password' do
           expected_incident = {
             short_description: short_description_regex('failed'),
-            description: 'This incident was created based on the following conditions: failures. See the PE console for the full report. You can access the PE console at test_console.',
+            description: %r{#{settings_hash['pe_console_url']}},
           }
           expect_created_incident(expected_incident, expected_credentials)
           processor.process
@@ -83,7 +83,7 @@ describe 'ServiceNow report processor: miscellaneous tests' do
         it 'decrypts the password' do
           expected_incident = {
             short_description: short_description_regex('failed'),
-            description: 'This incident was created based on the following conditions: failures. See the PE console for the full report. You can access the PE console at test_console.',
+            description: %r{#{settings_hash['pe_console_url']}},
           }
           expect_created_incident(expected_incident, expected_credentials)
           processor.process
@@ -111,7 +111,7 @@ describe 'ServiceNow report processor: miscellaneous tests' do
       it 'decrypts the oauth token' do
         expected_incident = {
           short_description: short_description_regex('failed'),
-          description: 'This incident was created based on the following conditions: failures. See the PE console for the full report. You can access the PE console at test_console.',
+          description: %r{#{settings_hash['pe_console_url']}},
         }
         expect_created_incident(expected_incident, oauth_token: 'test_token')
         processor.process


### PR DESCRIPTION
We remove the 'satisfied conditions' bit because the current
implementation is based off the incident creation conditions,
which are specific to incident management. Upcoming event management
work will add equivalent information to the description in a way that
can be shared by both incident and event management.

Signed-off-by: Enis Inan <enis.inan@puppet.com>