### PR TITLE
(PIE-358) Events with no changes now send a severity

### DIFF
--- a/lib/puppet/util/servicenow.rb
+++ b/lib/puppet/util/servicenow.rb
@@ -147,6 +147,8 @@ module Puppet::Util::Servicenow
     # 4 => Major....(Major functionality is severely impaired or performance has degraded.)
     # 5 => Critical.(The resource is either not functional or critical problems are imminent.)
     event_conditions = calculate_event_conditions(resource_statuses)
+    # return no_changes_event_severity in the case that there are no changes
+    return settings_hash['no_changes_event_severity'] unless event_conditions.values.any?
     event_conditions.select { |_, exists| exists == true }
                     .map { |condition, _| settings_hash[condition + '_event_severity'] }.sort.first
   end

--- a/manifests/event_management.pp
+++ b/manifests/event_management.pp
@@ -11,6 +11,7 @@ class servicenow_reporting_integration::event_management (
   Optional[Integer[0, 5]] $intentional_changes_event_severity         = 1,
   Optional[Integer[0, 5]] $pending_corrective_changes_event_severity  = 2,
   Optional[Integer[0, 5]] $pending_intentional_changes_event_severity = 1,
+  Optional[Integer[0, 5]] $no_changes_event_severity                  = 1,
 ) {
   class { 'servicenow_reporting_integration':
     operation_mode                             => 'event_management',
@@ -25,5 +26,6 @@ class servicenow_reporting_integration::event_management (
     intentional_changes_event_severity         => $intentional_changes_event_severity,
     pending_corrective_changes_event_severity  => $pending_corrective_changes_event_severity,
     pending_intentional_changes_event_severity => $pending_intentional_changes_event_severity,
+    no_changes_event_severity                  => $no_changes_event_severity,
   }
 }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -30,6 +30,7 @@ class servicenow_reporting_integration (
   Optional[Integer] $intentional_changes_event_severity                                                = undef,
   Optional[Integer] $pending_corrective_changes_event_severity                                         = undef,
   Optional[Integer] $pending_intentional_changes_event_severity                                        = undef,
+  Optional[Integer] $no_changes_event_severity                                                         = undef,
 ) {
   if (($user or $password) and $oauth_token) {
     fail('please specify either user/password or oauth_token not both.')
@@ -110,6 +111,7 @@ class servicenow_reporting_integration (
       intentional_changes_event_severity         => $intentional_changes_event_severity,
       pending_corrective_changes_event_severity  => $pending_corrective_changes_event_severity,
       pending_intentional_changes_event_severity => $pending_intentional_changes_event_severity,
+      no_changes_event_severity                  => $no_changes_event_severity,
       }),
     notify       => $settings_file_notify,
   }

--- a/spec/support/unit/reports/servicenow_spec_helpers.rb
+++ b/spec/support/unit/reports/servicenow_spec_helpers.rb
@@ -42,6 +42,7 @@ def default_settings_hash
     'intentional_changes_event_severity'         => 1,
     'pending_corrective_changes_event_severity'  => 2,
     'pending_intentional_changes_event_severity' => 1,
+    'no_changes_event_severity'                  => 5000,
   }
 end
 

--- a/spec/support/unit/reports/shared_examples.rb
+++ b/spec/support/unit/reports/shared_examples.rb
@@ -114,9 +114,9 @@ RSpec.shared_examples 'different message key' do
   end
 end
 
-RSpec.shared_examples 'event severity levels' do |status: 'success', event_corrective_change: true, expected_severity: '1'|
+RSpec.shared_examples 'event severity levels' do |status: 'success', event_corrective_change: true, expected_severity: '1', status_changed: true, status_failed: false|
   it "sends the appropriate event severity for status: #{status} and event corrective_change: #{event_corrective_change}" do
-    mock_event_as_resource_status(processor, status, event_corrective_change)
+    mock_event_as_resource_status(processor, status, event_corrective_change, status_changed, status_failed)
 
     expect_sent_event(expected_credentials) do |actual_event|
       expect(actual_event['severity']).to eql(expected_severity.to_s)

--- a/spec/unit/reports/servicenow/event_spec.rb
+++ b/spec/unit/reports/servicenow/event_spec.rb
@@ -132,11 +132,12 @@ describe 'ServiceNow report processor: event_management mode' do
   end
 
   context 'sends the appropriate event severity' do
-    examples = [{ status: 'failure', event_corrective_change: false, expected_severity: '3' },
-                { status: 'success', event_corrective_change: true,  expected_severity: '2' },
-                { status: 'noop',    event_corrective_change: true,  expected_severity: '2' },
-                { status: 'success', event_corrective_change: false, expected_severity: '1' },
-                { status: 'noop',    event_corrective_change: false, expected_severity: '1' }]
+    examples = [{ status: 'failure', event_corrective_change: false, expected_severity: '3',    status_changed: true,  status_failed: false },
+                { status: 'success', event_corrective_change: true,  expected_severity: '2',    status_changed: true,  status_failed: false },
+                { status: 'noop',    event_corrective_change: true,  expected_severity: '2',    status_changed: true,  status_failed: false },
+                { status: 'success', event_corrective_change: false, expected_severity: '1',    status_changed: true,  status_failed: false },
+                { status: 'noop',    event_corrective_change: false, expected_severity: '1',    status_changed: true,  status_failed: false },
+                { status: 'audit',   event_corrective_change: false, expected_severity: '5000', status_changed: false, status_failed: false }]
 
     examples.each do |example|
       include_examples 'event severity levels', example

--- a/templates/servicenow_reporting.yaml.epp
+++ b/templates/servicenow_reporting.yaml.epp
@@ -19,6 +19,7 @@
       Optional[Integer[0, 5]] $intentional_changes_event_severity,
       Optional[Integer[0, 5]] $pending_corrective_changes_event_severity,
       Optional[Integer[0, 5]] $pending_intentional_changes_event_severity,
+      Optional[Integer[0, 5]] $no_changes_event_severity,
       # Extra variables that _aren't_ part of the servicenow_reporting_integration
       # class' parameters go here
       String $report_processor_version,
@@ -46,4 +47,5 @@ corrective_changes_event_severity: <%= $corrective_changes_event_severity %>
 intentional_changes_event_severity: <%= $intentional_changes_event_severity %>
 pending_corrective_changes_event_severity: <%= $pending_corrective_changes_event_severity %>
 pending_intentional_changes_event_severity: <%= $pending_intentional_changes_event_severity %>
+no_changes_event_severity: <%= $no_changes_event_severity %>
 report_processor_version: <%= $report_processor_version %>


### PR DESCRIPTION
If an event status is not in one of the statuses returned by the
calculate_event_conditions method, a null status will be sent to
servicenow which creates an error on the servicenow end. This fix adds a
default status for no change statuses that is applied if a changed
status is not found. A test has been added with an absurd severity to
make sure there is no overlap with the other "1" severity statuses.