### PR TITLE
(PIE-352) Add Report Labels

### DIFF
--- a/lib/puppet/util/servicenow.rb
+++ b/lib/puppet/util/servicenow.rb
@@ -187,10 +187,12 @@ module Puppet::Util::Servicenow
 
   def report_description(settings_hash, resource_statuses)
     resourse_status_summary = human_readable_event_summary(resource_statuses)
+    labels                  = report_labels(resource_statuses)
     # Ideally, we'd like to link to the specific report here. However, fine-grained PE console links are
     # unstable even for Y PE releases (e.g. the link is different for PE 2019.2 and PE 2019.8). Thus, the
     # best and most stable solution we can do (for now) is the description you see here.
     description = "See the PE console for the full report. You can access the PE console at #{settings_hash['pe_console_url']}."
+    description << "\n\n#{labels}" unless labels.nil?
     description << "\n\nResource Statuses:\n#{resourse_status_summary}" unless resourse_status_summary.empty?
     description << "\n\n== Facts ==\n#{selected_facts(settings_hash)}"
     description
@@ -280,4 +282,12 @@ module Puppet::Util::Servicenow
     report_message_key_hash
   end
   module_function :calculate_report_message_key_hash
+end
+
+def report_labels(resource_statuses)
+  event_conditions = calculate_event_conditions(resource_statuses).select { |_, present| present == true }
+  labels = event_conditions.keys.map { |condition| "  #{condition}" }
+
+  "Report Labels:\n"\
+  "#{labels.join("\n")}"
 end

--- a/spec/acceptance/reporting/incident_spec.rb
+++ b/spec/acceptance/reporting/incident_spec.rb
@@ -120,6 +120,9 @@ describe 'ServiceNow reporting: incident creation' do
               expect(incident['description']).to match(%r{site.pp:2})
               expect(incident['description']).to match(%r{Notify\[foo_intentional_change\]\/message:})
               expect(incident['description']).to match(%r{site.pp:6})
+              expect(incident['description']).to match(%r{Report Labels:})
+              expect(incident['description']).to match(%r{corrective_changes})
+              expect(incident['description']).to match(%r{intentional_changes})
             }
           end
         end

--- a/spec/unit/reports/servicenow/event_spec.rb
+++ b/spec/unit/reports/servicenow/event_spec.rb
@@ -27,6 +27,7 @@ describe 'ServiceNow report processor: event_management mode' do
       expect(actual_event['description']).to match(%r{== Facts ==})
       expect(actual_event['description']).to match(%r{id: foo})
       expect(actual_event['description']).to match(%r{os.distro:\s+codename:[\s\S]*description})
+      expect(actual_event['description']).to match(%r{Report Labels:[\s\S]*intentional_changes})
       expect(actual_event['additional_information']).to match(%r{"facts"})
       expect(actual_event['additional_information']).to match(%r{"id": "foo"})
       expect(actual_event['additional_information']).to match(%r{"ipaddress": "192.168.0.1"})
@@ -97,6 +98,20 @@ describe 'ServiceNow report processor: event_management mode' do
       # The message key will be tested more thoroughly in other
       # tests
       expect(actual_event['message_key']).not_to be_empty
+    end
+
+    processor.process
+  end
+
+  it 'includes multiple labels in a description' do
+    events = [new_mock_event(status: 'success', corrective_change: true), new_mock_event(status: 'failure')]
+    mock_resource_statuses = new_mock_resource_status(events, true, true)
+    allow(processor).to receive(:resource_statuses).and_return('mock_resource' => mock_resource_statuses)
+
+    expect_sent_event(expected_credentials) do |actual_event|
+      expect(actual_event['description']).to match(%r{Report Labels:})
+      expect(actual_event['description']).to match(%r{failures})
+      expect(actual_event['description']).to match(%r{corrective_changes})
     end
 
     processor.process


### PR DESCRIPTION
This change adds report labels to the descriptions of both incidents and
events. The labels help users understand if what changes are represented
in a particular incident or report.

While the incident severity will only reflect the highest severity
change in the report, the labels will reflect all of the different
change types that may have been present in a given report.