### PR TITLE
(PIE-344) Add facts to the addtional information field

### DIFF
--- a/lib/puppet/reports/servicenow.rb
+++ b/lib/puppet/reports/servicenow.rb
@@ -21,15 +21,15 @@ Puppet::Reports.register_report(:servicenow) do
 
   def process_event_management(settings_hash)
     event_data = {
-      'source'      => 'Puppet',
-      'type'        => "node_report_#{status}",
-      # 5           => 'OK' severity
-      'severity'    => calculate_event_severity(resource_statuses, settings_hash).to_s,
-      'node'        => host,
+      'source'                 => 'Puppet',
+      'type'                   => "node_report_#{status}",
+      'severity'               => calculate_event_severity(resource_statuses, settings_hash).to_s,
+      'node'                   => host,
       # Source Instance is sent as event_class in the api
       # PuppetDB uses Puppet[:node_name_value] to determine the server name so this should be fine.
-      'event_class' => Puppet[:node_name_value],
-      'description' => report_description(settings_hash, resource_statuses),
+      'event_class'            => Puppet[:node_name_value],
+      'description'            => report_description(settings_hash, resource_statuses),
+      'additional_information' => event_additional_information,
     }
 
     # Compute the message key hash, which contains all relevant information

--- a/lib/puppet/util/servicenow.rb
+++ b/lib/puppet/util/servicenow.rb
@@ -235,6 +235,15 @@ module Puppet::Util::Servicenow
   end
   module_function :selected_facts
 
+  def event_additional_information
+    additional_information = {}
+    # If we wish to add other top level keys to the additional information field, add them here.
+    # Include all facts since this field is not intended for humans.
+    additional_information['facts'] = facts
+    JSON.pretty_generate(additional_information)
+  end
+  module_function :event_additional_information
+
   def format_report_timestamp(time, metrics)
     total_time = time + metrics['time']['total']
     short_date_time = total_time.strftime('%F %H:%M:%S %Z')

--- a/spec/acceptance/reporting/event_spec.rb
+++ b/spec/acceptance/reporting/event_spec.rb
@@ -33,6 +33,11 @@ describe 'ServiceNow reporting: event management' do
     expect(event['description']).to match(%r{== Facts ==})
     expect(event['description']).to match(%r{id: root})
     expect(event['description']).to match(%r{os.distro:\s+codename:[\s\S]*description})
+    expect(event['additional_information']).to match(%r{"facts"})
+    expect(event['additional_information']).to match(%r{"chassistype": "Other"})
+    expect(event['additional_information']).to match(%r{"manufacturer": "VMware, Inc."})
+    expect(event['additional_information']).to match(%r{"domain": "delivery.puppetlabs.net"})
+    expect(event['additional_information']).to match(%r{"kernel": "Linux"})
     # Check that the PE console URL is included
     expect(event['description']).to match(Regexp.new(Regexp.escape(master.uri)))
   end

--- a/spec/unit/reports/servicenow/event_spec.rb
+++ b/spec/unit/reports/servicenow/event_spec.rb
@@ -27,6 +27,11 @@ describe 'ServiceNow report processor: event_management mode' do
       expect(actual_event['description']).to match(%r{== Facts ==})
       expect(actual_event['description']).to match(%r{id: foo})
       expect(actual_event['description']).to match(%r{os.distro:\s+codename:[\s\S]*description})
+      expect(actual_event['additional_information']).to match(%r{"facts"})
+      expect(actual_event['additional_information']).to match(%r{"id": "foo"})
+      expect(actual_event['additional_information']).to match(%r{"ipaddress": "192.168.0.1"})
+      expect(actual_event['additional_information']).to match(%r{"memorysize": "7.80 GiB"})
+      expect(actual_event['additional_information']).to match(%r{"memoryfree": "2.05 GiB"})
       # The message key will be tested more thoroughly in other
       # tests
       expect(actual_event['message_key']).not_to be_empty
@@ -87,6 +92,8 @@ describe 'ServiceNow report processor: event_management mode' do
       expect(actual_event['node']).to eql('fqdn')
       expect(actual_event['description']).to match(%r{test_console})
       expect(actual_event['description']).not_to match(%r{Resource Statuses:})
+      expect(actual_event['additional_information']).to match(%r{"facts"})
+      expect(actual_event['additional_information']).to match(%r{"id": "foo"})
       # The message key will be tested more thoroughly in other
       # tests
       expect(actual_event['message_key']).not_to be_empty


### PR DESCRIPTION
This adds a method event_additional_information which returns a pretty
printed json hash of all facts under a top level 'facts' key. It will be
simple to add other top level keys to this method such as resources.
Tests for addtional information have been added but will need to made
more generic if the acceptance tests run on something other than
VMpooler.