### PR TITLE
(PIE-372) Create catalog failure report label

### DIFF
--- a/lib/puppet/reports/servicenow.rb
+++ b/lib/puppet/reports/servicenow.rb
@@ -23,12 +23,12 @@ Puppet::Reports.register_report(:servicenow) do
     event_data = {
       'source'          => 'Puppet',
       'type'            => "node_report_#{status}",
-      'severity'        => calculate_event_severity(resource_statuses, settings_hash).to_s,
+      'severity'        => calculate_event_severity(resource_statuses, settings_hash, transaction_completed).to_s,
       'node'            => host,
       # Source Instance is sent as event_class in the api
       # PuppetDB uses Puppet[:node_name_value] to determine the server name so this should be fine.
       'event_class'     => Puppet[:node_name_value],
-      'description'     => report_description(settings_hash, resource_statuses),
+      'description'     => report_description(settings_hash, resource_statuses, transaction_completed),
       'additional_info' => event_additional_information(settings_hash),
     }
 
@@ -72,7 +72,7 @@ Puppet::Reports.register_report(:servicenow) do
 
     Puppet.info(sn_log_entry("incident creation conditions: #{incident_creation_conditions}"))
 
-    satisfied_conditions = calculate_satisfied_conditions(status, resource_statuses, incident_creation_conditions)
+    satisfied_conditions = calculate_satisfied_conditions(status, resource_statuses, incident_creation_conditions, transaction_completed)
 
     if satisfied_conditions.empty?
       Puppet.info(sn_log_entry('decision: Do not create incident'))
@@ -83,7 +83,7 @@ Puppet::Reports.register_report(:servicenow) do
     short_description_status = noop_pending ? 'pending changes' : status
     incident_data = {
       short_description: "Puppet run report (status: #{short_description_status}) for node #{host} environment #{environment} (report time: #{format_report_timestamp(time, metrics)})",
-      description: report_description(settings_hash, resource_statuses),
+      description: report_description(settings_hash, resource_statuses, transaction_completed),
       caller_id: settings_hash['caller_id'],
       category: settings_hash['category'],
       subcategory: settings_hash['subcategory'],

--- a/spec/acceptance/reporting/event_spec.rb
+++ b/spec/acceptance/reporting/event_spec.rb
@@ -45,4 +45,15 @@ describe 'ServiceNow reporting: event management' do
     # Check that the PE console URL is included
     expect(event['description']).to match(Regexp.new(Regexp.escape(master.uri)))
   end
+
+  it 'handles a catalog failure properly' do
+    set_sitepp_content("notify {'foo")
+    trigger_puppet_run(master, acceptable_exit_codes: [1])
+    set_sitepp_content('')
+    event = Helpers.get_single_record('em_event', query)
+
+    expect(event['description']).to match(%r{Report Labels:[\s\S]*catalog_failure})
+    expect(event['description']).to match(%r{Log Output:})
+    expect(event['type']).to eql('node_report_failed')
+  end
 end

--- a/spec/support/unit/reports/shared_examples.rb
+++ b/spec/support/unit/reports/shared_examples.rb
@@ -82,8 +82,12 @@ RSpec.shared_examples 'ictc' do |report_label: nil, noop_test: false|
         'pending'
       when 'no_changes'
         before(:each) do
+          resource_statuses = instance_double('resource_statuses')
+          allow(resource_statuses).to receive(:empty?).and_return(false)
+          allow(resource_statuses).to receive(:values).and_return([])
           allow(processor).to receive(:status).and_return('unchanged')
           allow(processor).to receive(:noop_pending).and_return(false)
+          allow(processor).to receive(:resource_statuses).and_return(resource_statuses)
         end
 
         'unchanged'


### PR DESCRIPTION
Previously when a puppet run resulted in a catalog failure, there were
no report labels populated in the report description.

This change ensures that if a catalog failure occurs there is a report
label is still generated, and additionally the log messages are
included. We include the log messages in the case of catalog failure
because otherwise there is no way to provide the user with feedback
on what might have caused the failure.