### PR TITLE
(PIE-376) Allow instance parameter to accept protocol

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ The module can send events or it can create incidents, but attempting to do both
 
 ### Events
 
-To send events, classify your Puppet servers with the `servicenow_reporting_integration::event_management` class. The minimum parameters you need to configure for the class to work are instance (the fqdn of the servicenow instance, not including the protocol e.g. https://), and then user and password, or you can bypass username/password authentication and use an oauth token using the oauth_token parameter.
+To send events, classify your Puppet servers with the `servicenow_reporting_integration::event_management` class. The minimum parameters you need to configure for the class to work are instance (the fqdn of the servicenow instance), and then user and password, or you can bypass username/password authentication and use an oauth token using the oauth_token parameter.
 
 By default each event will include the following information:
 * __Source__: Puppet

--- a/files/validate_settings.rb
+++ b/files/validate_settings.rb
@@ -37,7 +37,7 @@ end
 
 # Validate the ServiceNow credentials
 begin
-  endpoint = "https://#{settings['instance']}/api/now/table/#{validation_table}?sysparm_limit=1"
+  endpoint = "#{instance_with_protocol(settings['instance'])}/api/now/table/#{validation_table}?sysparm_limit=1"
   response = Puppet::Util::Servicenow.do_snow_request(
     endpoint,
     'Get',

--- a/lib/puppet/reports/servicenow.rb
+++ b/lib/puppet/reports/servicenow.rb
@@ -45,7 +45,7 @@ Puppet::Reports.register_report(:servicenow) do
     event_data['message_key'] = Digest::SHA1.hexdigest(message_key_hash.to_json.chars.sort.join)
 
     # Now send the event
-    endpoint = "https://#{settings_hash['instance']}/api/global/em/jsonv2"
+    endpoint = "#{instance_with_protocol(settings_hash['instance'])}/api/global/em/jsonv2"
 
     Puppet.info(sn_log_entry("attempting to send the #{event_data['type']} event on #{endpoint}"))
 
@@ -95,7 +95,7 @@ Puppet::Reports.register_report(:servicenow) do
       assigned_to: settings_hash['assigned_to'],
     }
 
-    endpoint = "https://#{settings_hash['instance']}/api/now/table/incident"
+    endpoint = "#{instance_with_protocol(settings_hash['instance'])}/api/now/table/incident"
 
     Puppet.info(sn_log_entry("attempting to create incident on #{endpoint}"))
 

--- a/lib/puppet/util/servicenow.rb
+++ b/lib/puppet/util/servicenow.rb
@@ -293,3 +293,12 @@ def report_labels(resource_statuses)
   "Report Labels:\n"\
   "#{labels.join("\n")}"
 end
+
+# takes the instance string from the settings and prepends 'https://' if not already present.
+def instance_with_protocol(instance)
+  if instance[0..7] == 'https://'
+    instance
+  else
+    'https://' << instance
+  end
+end

--- a/manifests/event_management.pp
+++ b/manifests/event_management.pp
@@ -3,7 +3,7 @@
 # @example
 #   include servicenow_reporting_integration::event_management
 # @param [String[1]] instance
-#   The FQDN of the ServiceNow instance. Only the FQDN. Do not include the protocol
+#   The FQDN of the ServiceNow instance.
 # @param [Optional[String[1]]] user
 #   A user that has permission to send events
 # @param [Optional[String[1]]] password

--- a/tasks/add_ignore_ok_events_rule.rb
+++ b/tasks/add_ignore_ok_events_rule.rb
@@ -30,7 +30,7 @@ class ServiceNowEventRuleCreate < TaskHelper
     oauth_token = _target[:oauth_token] if oauth_token.nil?
     instance    = _target[:uri]         if instance.nil?
 
-    uri = "https://#{instance}/api/now/table/em_match_rule"
+    uri = "#{instance_with_protocol(instance)}/api/now/table/em_match_rule"
 
     begin
       response = Puppet::Util::Servicenow.do_snow_request(uri,


### PR DESCRIPTION
Currently if you include protocol ('https://') in the instance parameter
string you get an error. Added a method to prepend the https if not
already present.