### PR TITLE
(PIE-378) Send Only Queried Facts

### DIFF
--- a/lib/puppet/reports/servicenow.rb
+++ b/lib/puppet/reports/servicenow.rb
@@ -29,7 +29,7 @@ Puppet::Reports.register_report(:servicenow) do
       # PuppetDB uses Puppet[:node_name_value] to determine the server name so this should be fine.
       'event_class'     => Puppet[:node_name_value],
       'description'     => report_description(settings_hash, resource_statuses),
-      'additional_info' => event_additional_information,
+      'additional_info' => event_additional_information(settings_hash),
     }
 
     # Compute the message key hash, which contains all relevant information

--- a/lib/puppet/util/servicenow.rb
+++ b/lib/puppet/util/servicenow.rb
@@ -238,12 +238,12 @@ module Puppet::Util::Servicenow
   end
   module_function :selected_facts
 
-  def event_additional_information
+  def event_additional_information(settings_hash)
     additional_information = {}
     # If we wish to add other top level keys to the additional information field, add them here.
     # Include all facts since this field is not intended for humans.
-    additional_information['facts'] = facts
     additional_information['environment'] = environment
+    additional_information.merge!(selected_facts(settings_hash, nil, :object))
     JSON.pretty_generate(additional_information)
   end
   module_function :event_additional_information

--- a/spec/acceptance/reporting/event_spec.rb
+++ b/spec/acceptance/reporting/event_spec.rb
@@ -21,6 +21,8 @@ describe 'ServiceNow reporting: event management' do
     trigger_puppet_run(master, acceptable_exit_codes: [2])
     event = Helpers.get_single_record('em_event', query)
 
+    additional_info = JSON.parse(event['additional_info'])
+
     expect(event['source']).to eql('Puppet')
     expect(event['type']).to eql('node_report_changed')
     expect(event['severity']).to eql('1')
@@ -36,12 +38,10 @@ describe 'ServiceNow reporting: event management' do
     expect(event['description']).to match(%r{== Facts ==})
     expect(event['description']).to match(%r{id: root})
     expect(event['description']).to match(%r{os.distro:\s+codename:[\s\S]*description})
-    expect(event['additional_info']).to match(%r{"facts"})
-    expect(event['additional_info']).to match(%r{"environment": "production})
-    expect(event['additional_info']).to match(%r{"chassistype": "Other"})
-    expect(event['additional_info']).to match(%r{"manufacturer": "VMware, Inc."})
-    expect(event['additional_info']).to match(%r{"domain": "delivery.puppetlabs.net"})
-    expect(event['additional_info']).to match(%r{"kernel": "Linux"})
+    expect(additional_info['environment']).to eql('production')
+    expect(additional_info['id']).to eql('root')
+    expect(additional_info['ipaddress']).to match(%r{^(?:[0-9]{1,3}\.){3}[0-9]{1,3}$})
+    expect(additional_info['os.distro']['codename']).not_to be_empty
     # Check that the PE console URL is included
     expect(event['description']).to match(Regexp.new(Regexp.escape(master.uri)))
   end

--- a/spec/support/unit/reports/servicenow_spec_helpers.rb
+++ b/spec/support/unit/reports/servicenow_spec_helpers.rb
@@ -45,7 +45,7 @@ def default_settings_hash
     'pending_intentional_changes_event_severity' => 1,
     'no_changes_event_severity'                  => 5000,
     'facts_format'                               => 'yaml',
-    'include_facts'                              => ['id', 'os.distro'],
+    'include_facts'                              => ['id', 'os.distro', 'ipaddress'],
   }
 end
 

--- a/spec/unit/reports/servicenow/event_spec.rb
+++ b/spec/unit/reports/servicenow/event_spec.rb
@@ -17,6 +17,7 @@ describe 'ServiceNow report processor: event_management mode' do
     mock_event_as_resource_status(processor, 'success', false)
 
     expect_sent_event(expected_credentials) do |actual_event|
+      additional_info = JSON.parse(actual_event['additional_info'])
       expect(actual_event['source']).to eql('Puppet')
       expect(actual_event['type']).to eql('node_report_changed')
       expect(actual_event['severity']).to eql('1')
@@ -29,12 +30,10 @@ describe 'ServiceNow report processor: event_management mode' do
       expect(actual_event['description']).to match(%r{id: foo})
       expect(actual_event['description']).to match(%r{os.distro:\s+codename:[\s\S]*description})
       expect(actual_event['description']).to match(%r{Report Labels:[\s\S]*intentional_changes})
-      expect(actual_event['additional_info']).to match(%r{"facts"})
-      expect(actual_event['additional_info']).to match(%r{"id": "foo"})
-      expect(actual_event['additional_info']).to match(%r{"environment": "production})
-      expect(actual_event['additional_info']).to match(%r{"ipaddress": "192.168.0.1"})
-      expect(actual_event['additional_info']).to match(%r{"memorysize": "7.80 GiB"})
-      expect(actual_event['additional_info']).to match(%r{"memoryfree": "2.05 GiB"})
+      expect(additional_info['id']).to eql('foo')
+      expect(additional_info['environment']).to eql('production')
+      expect(additional_info['ipaddress']).to eql('192.168.0.1')
+      expect(additional_info['os.distro']['codename']).to eql('xenial')
       # The message key will be tested more thoroughly in other
       # tests
       expect(actual_event['message_key']).not_to be_empty
@@ -89,14 +88,18 @@ describe 'ServiceNow report processor: event_management mode' do
     mock_event_as_resource_status(processor, 'success', false, false)
 
     expect_sent_event(expected_credentials) do |actual_event|
+      additional_info = JSON.parse(actual_event['additional_info'])
+
       expect(actual_event['source']).to eql('Puppet')
       expect(actual_event['type']).to eql('node_report_unchanged')
       expect(actual_event['severity']).to eql('1')
       expect(actual_event['node']).to eql('fqdn')
       expect(actual_event['description']).to match(%r{test_console})
       expect(actual_event['description']).not_to match(%r{Resource Statuses:})
-      expect(actual_event['additional_info']).to match(%r{"facts"})
-      expect(actual_event['additional_info']).to match(%r{"id": "foo"})
+      expect(additional_info['id']).to eql('foo')
+      expect(additional_info['environment']).to eql('production')
+      expect(additional_info['ipaddress']).to eql('192.168.0.1')
+      expect(additional_info['os.distro']['codename']).to eql('xenial')
       # The message key will be tested more thoroughly in other
       # tests
       expect(actual_event['message_key']).not_to be_empty


### PR DESCRIPTION
This change ensures that only facts queried via the $include_facts
parameter. It also switches to adding each fact to the additional_info
field as a top level key to make it easier to target the facts with
event rules.