### PR TITLE
(PIE-375) Include Report Labels in Additional Info

### DIFF
--- a/lib/puppet/reports/servicenow.rb
+++ b/lib/puppet/reports/servicenow.rb
@@ -29,7 +29,7 @@ Puppet::Reports.register_report(:servicenow) do
       # PuppetDB uses Puppet[:node_name_value] to determine the server name so this should be fine.
       'event_class'     => Puppet[:node_name_value],
       'description'     => report_description(settings_hash, resource_statuses, transaction_completed),
-      'additional_info' => event_additional_information(settings_hash),
+      'additional_info' => event_additional_information(settings_hash, resource_statuses, transaction_completed),
     }
 
     # Compute the message key hash, which contains all relevant information

--- a/spec/acceptance/reporting/event_spec.rb
+++ b/spec/acceptance/reporting/event_spec.rb
@@ -20,7 +20,6 @@ describe 'ServiceNow reporting: event management' do
     set_sitepp_content(declare('notify', 'foo'))
     trigger_puppet_run(master, acceptable_exit_codes: [2])
     event = Helpers.get_single_record('em_event', query)
-
     additional_info = JSON.parse(event['additional_info'])
 
     expect(event['source']).to eql('Puppet')
@@ -42,6 +41,7 @@ describe 'ServiceNow reporting: event management' do
     expect(additional_info['id']).to eql('root')
     expect(additional_info['ipaddress']).to match(%r{^(?:[0-9]{1,3}\.){3}[0-9]{1,3}$})
     expect(additional_info['os.distro']['codename']).not_to be_empty
+    expect(additional_info['report_labels']).to eql('intentional_changes')
     # Check that the PE console URL is included
     expect(event['description']).to match(Regexp.new(Regexp.escape(master.uri)))
   end


### PR DESCRIPTION
It's much easier to create rules in servicenow from top level keys in
the additional information field, so this adds the report labels to the
additional info.