### PR TITLE
(PIE-394) Enable Certificate Validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,8 @@ Each incident will include the following information provided by Puppet:
 
 To verify that everything worked, trigger a Puppet run on one of the nodes in the `PE Master` node group then log into the node. Once logged in, run `sudo tail -n 60 /var/log/puppetlabs/puppetserver/puppetserver.log | grep servicenow`. You should see some output. If not, then the class is probably not being classified properly. Either the class is not being assigned to the Puppet server nodes at all, or there may be catalog compilation errors on those nodes with the provided parameter values. Please use GitHub issues to file any bugs you find during your troubleshooting.
 
+If you try to use the module and it doesn't work because of certificate validation errors, you can use the `skip_certificate_validation` parameter to disable certificate validation. The connection will still be SSL encrypted, but no certificate validation will be performed, which opens up a risk of 'Man in the middle' attacks. But, if you are using an internally hosted Servicenow instance that uses an SSL certificate that has not been imported for trust on the Puppet server machine, this may be necessary. Cloud hosted instances of Servicenow typically use a certificate signed by a well know public certificate authority, in which case, this parameter is not necessary.
+
 ## Development
 
 ### Unit tests

--- a/lib/puppet/reports/servicenow.rb
+++ b/lib/puppet/reports/servicenow.rb
@@ -54,7 +54,8 @@ Puppet::Reports.register_report(:servicenow) do
                                { records: [event_data] },
                                user: settings_hash['user'],
                                password: settings_hash['password'],
-                               oauth_token: settings_hash['oauth_token'])
+                               oauth_token: settings_hash['oauth_token'],
+                               skip_cert_check: settings['skip_certificate_validation'])
 
     raise "Failed to send the event. Error from #{endpoint} (status: #{response.code}): #{response.body}" if response.code.to_i >= 300
 
@@ -104,7 +105,8 @@ Puppet::Reports.register_report(:servicenow) do
                                incident_data,
                                user: settings_hash['user'],
                                password: settings_hash['password'],
-                               oauth_token: settings_hash['oauth_token'])
+                               oauth_token: settings_hash['oauth_token'],
+                               skip_cert_check: settings['skip_certificate_validation'])
 
     raise "Incident creation failed. Error from #{endpoint} (status: #{response.code}): #{response.body}" if response.code.to_i >= 300
 

--- a/lib/puppet/util/servicenow.rb
+++ b/lib/puppet/util/servicenow.rb
@@ -71,13 +71,18 @@ module Puppet::Util::Servicenow
   end
   module_function :settings
 
-  def do_snow_request(uri, http_verb, body, user: nil, password: nil, oauth_token: nil)
+  def do_snow_request(uri, http_verb, body, user: nil, password: nil, oauth_token: nil, skip_cert_check: false)
     uri = URI.parse(uri)
+    verify_mode = skip_cert_check ? OpenSSL::SSL::VERIFY_NONE : OpenSSL::SSL::VERIFY_PEER
+
+    opts = {
+      use_ssl: uri.scheme == 'https',
+      verify_mode: verify_mode,
+    }
 
     Net::HTTP.start(uri.host,
                     uri.port,
-                    use_ssl: uri.scheme == 'https',
-                    verify_mode: OpenSSL::SSL::VERIFY_NONE) do |http|
+                    opts) do |http|
       header = { 'Content-Type' => 'application/json' }
       # Interpolate the HTTP verb and constantize to a class name.
       request_class_string = "Net::HTTP::#{http_verb.capitalize}"

--- a/manifests/event_management.pp
+++ b/manifests/event_management.pp
@@ -37,6 +37,11 @@
 #   Turn off sending events from the report processor. This is an easier way to
 #   disable the module temporarily instead of uninstalling the module and
 #   removing the setting from puppet.conf.
+# @param [Optional[Boolean]] skip_certificate_validation
+#   If your Servicenow instance uses a certificate that is not trusted by the
+#   Puppet server, you can set this parameter to 'true'. The connection will
+#   still use SSL, but the module will not perform certificate validation, which
+#   is a risk for man in the middle attacks.
 
 class servicenow_reporting_integration::event_management (
   String[1] $instance,
@@ -54,6 +59,7 @@ class servicenow_reporting_integration::event_management (
   Optional[Array[String[1]]] $include_facts                                                               = ['aio_agent_version', 'id', 'memorysize', 'memoryfree', 'ipaddress', 'ipaddress6', 'os.distro', 'os.windows', 'path', 'uptime', 'rubyversion'],
   Enum['yaml', 'pretty_json', 'json'] $facts_format                                                       = 'yaml',
   Optional[Boolean] $disabled                                                                             = false,
+  Optional[Boolean] $skip_certificate_validation                                                          = false,
 ) {
   class { 'servicenow_reporting_integration':
     operation_mode                             => 'event_management',
@@ -72,5 +78,6 @@ class servicenow_reporting_integration::event_management (
     include_facts                              => $include_facts,
     facts_format                               => $facts_format,
     disabled                                   => $disabled,
+    skip_certificate_validation                => $skip_certificate_validation,
   }
 }

--- a/manifests/incident_management.pp
+++ b/manifests/incident_management.pp
@@ -55,6 +55,11 @@
 #   nested facts like 'os.distro'
 # @param [Enum['yaml', 'pretty_jason', 'json']] facts_format
 #   The format of the facts that are included in the event description
+# @param [Optional[Boolean]] skip_certificate_validation
+#   If your Servicenow instance uses a certificate that is not trusted by the
+#   Puppet server, you can set this parameter to 'true'. The connection will
+#   still use SSL, but the module will not perform certificate validation, which
+#   is a risk for man in the middle attacks.
 class servicenow_reporting_integration::incident_management (
   String[1] $instance,
   String[1] $caller_id,
@@ -74,6 +79,7 @@ class servicenow_reporting_integration::incident_management (
   String $servicenow_credentials_validation_table                                            = 'incident',
   Optional[Array[String[1]]] $include_facts                                                  = ['aio_agent_version', 'id', 'memorysize', 'memoryfree', 'ipaddress', 'ipaddress6', 'os.distro', 'os.windows', 'path', 'uptime', 'rubyversion'],
   Enum['yaml', 'pretty_json', 'json'] $facts_format                                          = 'yaml',
+  Optional[Boolean] $skip_certificate_validation                                             = false,
 ) {
   class { 'servicenow_reporting_integration':
     operation_mode                          => 'incident_management',
@@ -95,5 +101,6 @@ class servicenow_reporting_integration::incident_management (
     servicenow_credentials_validation_table => $servicenow_credentials_validation_table,
     include_facts                           => $include_facts,
     facts_format                            => $facts_format,
+    skip_certificate_validation             => $skip_certificate_validation,
   }
 }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -15,6 +15,7 @@ class servicenow_reporting_integration (
   Optional[String[1]] $pe_console_url                                                                     = undef,
   Optional[Array[String[1]]] $include_facts                                                               = ['identity.user', 'ipaddress','memorysize', 'memoryfree', 'os'],
   Enum['yaml', 'pretty_json', 'json'] $facts_format                                                       = 'pretty_json',
+  Optional[Boolean] $skip_certificate_validation                                                          = false,
   # PARAMETERS SPECIFIC TO INCIDENT_MANAGEMENT
   Optional[String[1]] $caller_id                                                                          = undef,
   Optional[String[1]] $category                                                                           = undef,
@@ -118,6 +119,7 @@ class servicenow_reporting_integration (
       include_facts                              => $include_facts,
       facts_format                               => $facts_format,
       disabled                                   => $disabled,
+      skip_certificate_validation                => $skip_certificate_validation,
       }),
     notify       => $settings_file_notify,
   }

--- a/spec/acceptance/reporting/event_spec.rb
+++ b/spec/acceptance/reporting/event_spec.rb
@@ -8,6 +8,7 @@ describe 'ServiceNow reporting: event management' do
       instance: servicenow_instance.uri,
       user: servicenow_config['user'],
       password: servicenow_config['password'],
+      skip_certificate_validation: Helpers.skip_cert_check?,
     }
   end
   let(:setup_manifest) do

--- a/spec/acceptance/reporting/incident_spec.rb
+++ b/spec/acceptance/reporting/incident_spec.rb
@@ -30,6 +30,7 @@ describe 'ServiceNow reporting: incident creation' do
       caller_id: kaller['sys_id'],
       user: servicenow_config['user'],
       password: servicenow_config['password'],
+      skip_certificate_validation: Helpers.skip_cert_check?,
     }
   end
   let(:setup_manifest) do

--- a/spec/support/acceptance/helpers.rb
+++ b/spec/support/acceptance/helpers.rb
@@ -124,4 +124,12 @@ module Helpers
     end
   end
   module_function :delete_records
+
+  def skip_cert_check?
+    # If the uri for the servicenow instance is just the uri for the master with
+    # the port at the end, then we assume that it's just the container.
+    # The container uses a self signed cert, so we have to skip the cert check.
+    servicenow_instance.uri.include? master.uri
+  end
+  module_function :skip_cert_check?
 end

--- a/templates/servicenow_reporting.yaml.epp
+++ b/templates/servicenow_reporting.yaml.epp
@@ -23,6 +23,7 @@
       Array[String] $include_facts,
       String $facts_format,
       Optional[Boolean] $disabled,
+      Optional[Boolean] $skip_certificate_validation,
       # Extra variables that _aren't_ part of the servicenow_reporting_integration
       # class' parameters go here
       String $report_processor_version,
@@ -54,4 +55,5 @@ no_changes_event_severity: <%= $no_changes_event_severity %>
 include_facts: <%= $include_facts %>
 facts_format: <%= $facts_format %>
 disabled: <%= $disabled %>
+skip_certificate_validation: <%= $skip_certificate_validation %>
 report_processor_version: <%= $report_processor_version %>


### PR DESCRIPTION
Prior to this change, all HTTP requests were done with no SSL
certificate validation.

This change ensures that normal SSL cert validation is done by default,
but users can also turn it off if needed via an opt in parameter.