### PR TITLE
(PIE-382) Add Resource Events to Additional Info

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ By default each event will include the following information:
 * __Additional Information__: The additional information field contains data about the event in JSON format to make it easy to target that information for rules and workflows. It contains the following keys
   * __Facts__: A json format representation of all of the facts from the node where Puppet ran.
   * __Node Environment__: The environment the node is assigned to
+  * __resource_events__: A list of event summaries categorized by intentional and corrective change event types.
 
 The module will send a single event for every Puppet run on every node. If nothing interesting such as changes or a failure happened in a given Puppet run then the event type will be `node_report_unchanged`, there will be no resources listed in the description, and the report severity default value will be `OK`.
 

--- a/spec/acceptance/reporting/event_spec.rb
+++ b/spec/acceptance/reporting/event_spec.rb
@@ -42,6 +42,9 @@ describe 'ServiceNow reporting: event management' do
     expect(additional_info['ipaddress']).to match(%r{^(?:[0-9]{1,3}\.){3}[0-9]{1,3}$})
     expect(additional_info['os.distro']['codename']).not_to be_empty
     expect(additional_info['report_labels']).to eql('intentional_changes')
+    expect(additional_info['resource_events'].to_json).to match(%r{corrective_changes})
+    expect(additional_info['resource_events'].to_json).to match(%r{intentional_changes})
+    expect(additional_info['resource_events'].to_json).to match(%r{Notify})
     # Check that the PE console URL is included
     expect(event['description']).to match(Regexp.new(Regexp.escape(master.uri)))
   end

--- a/spec/support/unit/reports/servicenow_spec_helpers.rb
+++ b/spec/support/unit/reports/servicenow_spec_helpers.rb
@@ -80,6 +80,10 @@ def new_mock_resource_status(events, status_changed, status_failed)
   allow(status).to receive(:containment_path).and_return(['foo', 'bar'])
   allow(status).to receive(:file).and_return('site.pp')
   allow(status).to receive(:line).and_return(1)
+  allow(status).to receive(:resource).and_return('resource')
+  allow(status).to receive(:resource_type).and_return('resource_type')
+  allow(status).to receive(:corrective_change).and_return(true)
+  allow(status).to receive(:intentional_change).and_return(false)
   status
 end
 

--- a/spec/unit/reports/servicenow/event_spec.rb
+++ b/spec/unit/reports/servicenow/event_spec.rb
@@ -34,6 +34,7 @@ describe 'ServiceNow report processor: event_management mode' do
       expect(additional_info['environment']).to eql('production')
       expect(additional_info['ipaddress']).to eql('192.168.0.1')
       expect(additional_info['os.distro']['codename']).to eql('xenial')
+      expect(additional_info['resource_events']['corrective_changes'].first['containment_path']).to eql(['foo', 'bar'])
       # The message key will be tested more thoroughly in other
       # tests
       expect(actual_event['message_key']).not_to be_empty


### PR DESCRIPTION
Add a resource_events key to the event additional information field
which contains two additional keys, corrective_changes, and intentional
changes. These keys contain arrays of relevant events. The total
possible set of events is filtered to the same set as already exists in
the description.