### PR TITLE
(PIE-383) Add HTTP Timeout Parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,8 @@ To verify that everything worked, trigger a Puppet run on one of the nodes in th
 
 If you try to use the module and it doesn't work because of certificate validation errors, you can use the `skip_certificate_validation` parameter to disable certificate validation. The connection will still be SSL encrypted, but no certificate validation will be performed, which opens up a risk of 'Man in the middle' attacks. But, if you are using an internally hosted Servicenow instance that uses an SSL certificate that has not been imported for trust on the Puppet server machine, this may be necessary. Cloud hosted instances of Servicenow typically use a certificate signed by a well know public certificate authority, in which case, this parameter is not necessary.
 
+If the module starts to throw errors indicating failures due to HTTP timeouts, you can try to use the `http_read_timeout` and `http_write_timeout` parameters to extend the amount of time available to complete a Servicenow API request.
+
 ## Development
 
 ### Unit tests

--- a/lib/puppet/reports/servicenow.rb
+++ b/lib/puppet/reports/servicenow.rb
@@ -55,7 +55,9 @@ Puppet::Reports.register_report(:servicenow) do
                                user: settings_hash['user'],
                                password: settings_hash['password'],
                                oauth_token: settings_hash['oauth_token'],
-                               skip_cert_check: settings['skip_certificate_validation'])
+                               skip_cert_check: settings['skip_certificate_validation'],
+                               read_timeout: settings['http_read_timeout'],
+                               write_timeout: settings['http_write_timeout'])
 
     raise "Failed to send the event. Error from #{endpoint} (status: #{response.code}): #{response.body}" if response.code.to_i >= 300
 
@@ -106,7 +108,9 @@ Puppet::Reports.register_report(:servicenow) do
                                user: settings_hash['user'],
                                password: settings_hash['password'],
                                oauth_token: settings_hash['oauth_token'],
-                               skip_cert_check: settings['skip_certificate_validation'])
+                               skip_cert_check: settings['skip_certificate_validation'],
+                               read_timeout: settings['http_read_timeout'],
+                               write_timeout: settings['http_write_timeout'])
 
     raise "Incident creation failed. Error from #{endpoint} (status: #{response.code}): #{response.body}" if response.code.to_i >= 300
 

--- a/lib/puppet/util/servicenow.rb
+++ b/lib/puppet/util/servicenow.rb
@@ -71,13 +71,21 @@ module Puppet::Util::Servicenow
   end
   module_function :settings
 
-  def do_snow_request(uri, http_verb, body, user: nil, password: nil, oauth_token: nil, skip_cert_check: false)
+  def do_snow_request(uri, http_verb, body, user: nil, password: nil, oauth_token: nil, skip_cert_check: false, read_timeout: 60, write_timeout: 60)
     uri = URI.parse(uri)
     verify_mode = skip_cert_check ? OpenSSL::SSL::VERIFY_NONE : OpenSSL::SSL::VERIFY_PEER
 
+    # We're going to set the connect timeout and the read timeout to the same
+    # value, because in most user's minds these are functionally the same
+    # timeout, and until we get some specific push for separating them out
+    # we don't want to make the module more complex for users to understand.
     opts = {
-      use_ssl: uri.scheme == 'https',
-      verify_mode: verify_mode,
+      use_ssl:         uri.scheme == 'https',
+      verify_mode:     verify_mode,
+      read_timeout:    read_timeout,
+      connect_timeout: read_timeout,
+      ssl_timeout:     read_timeout,
+      write_timeout:   write_timeout,
     }
 
     Net::HTTP.start(uri.host,

--- a/manifests/event_management.pp
+++ b/manifests/event_management.pp
@@ -42,6 +42,18 @@
 #   Puppet server, you can set this parameter to 'true'. The connection will
 #   still use SSL, but the module will not perform certificate validation, which
 #   is a risk for man in the middle attacks.
+# @param [Optional[Variant[Integer[0], Float[0]]]] http_read_timeout
+#   The read timeout parameter sets an upper limit on how long HTTP read
+#   read operations should take. For the sake simplicity, this paramter sets
+#   three different arguments to the Net::HTTP.start method: read_timeout,
+#   connect_timeout, ssl_timeout. This type is a Float because those argumants
+#   can all accept fractional seconds values. The default value of 60 seconds
+#   is also the default value for that Ruby class if no argument is passed
+# @param [Optional[Variant[Integer[0], Float[0]]]] http_write_timeout
+#   Sets the write_timeout argument to the Net::HTTP.start method. The datatype
+#   is a float because it accepts fractions seconds values. The default value of
+#   60 seconds is also the default value for that Ruby class if no argument is
+#   passed
 
 class servicenow_reporting_integration::event_management (
   String[1] $instance,
@@ -60,6 +72,8 @@ class servicenow_reporting_integration::event_management (
   Enum['yaml', 'pretty_json', 'json'] $facts_format                                                       = 'yaml',
   Optional[Boolean] $disabled                                                                             = false,
   Optional[Boolean] $skip_certificate_validation                                                          = false,
+  Optional[Variant[Integer[0], Float[0]]] $http_read_timeout                                              = 60,
+  Optional[Variant[Integer[0], Float[0]]] $http_write_timeout                                             = 60,
 ) {
   class { 'servicenow_reporting_integration':
     operation_mode                             => 'event_management',
@@ -79,5 +93,7 @@ class servicenow_reporting_integration::event_management (
     facts_format                               => $facts_format,
     disabled                                   => $disabled,
     skip_certificate_validation                => $skip_certificate_validation,
+    http_read_timeout                          => $http_read_timeout,
+    http_write_timeout                         => $http_write_timeout,
   }
 }

--- a/manifests/incident_management.pp
+++ b/manifests/incident_management.pp
@@ -60,6 +60,18 @@
 #   Puppet server, you can set this parameter to 'true'. The connection will
 #   still use SSL, but the module will not perform certificate validation, which
 #   is a risk for man in the middle attacks.
+# @param [Optional[Variant[Integer[0], Float[0]]]] http_read_timeout
+#   The read timeout parameter sets an upper limit on how long HTTP read
+#   read operations should take. For the sake simplicity, this paramter sets
+#   three different arguments to the Net::HTTP.start method: read_timeout,
+#   connect_timeout, ssl_timeout. This type is a Float because those argumants
+#   can all accept fractional seconds values. The default value of 60 seconds
+#   is also the default value for that Ruby class if no argument is passed
+# @param [Optional[Variant[Integer[0], Float[0]]]] http_write_timeout
+#   Sets the write_timeout argument to the Net::HTTP.start method. The datatype
+#   is a float because it accepts fractions seconds values. The default value of
+#   60 seconds is also the default value for that Ruby class if no argument is
+#   passed
 class servicenow_reporting_integration::incident_management (
   String[1] $instance,
   String[1] $caller_id,
@@ -80,6 +92,8 @@ class servicenow_reporting_integration::incident_management (
   Optional[Array[String[1]]] $include_facts                                                  = ['aio_agent_version', 'id', 'memorysize', 'memoryfree', 'ipaddress', 'ipaddress6', 'os.distro', 'os.windows', 'path', 'uptime', 'rubyversion'],
   Enum['yaml', 'pretty_json', 'json'] $facts_format                                          = 'yaml',
   Optional[Boolean] $skip_certificate_validation                                             = false,
+  Optional[Variant[Integer[0], Float[0]]] $http_read_timeout                                 = 60,
+  Optional[Variant[Integer[0], Float[0]]] $http_write_timeout                                = 60,
 ) {
   class { 'servicenow_reporting_integration':
     operation_mode                          => 'incident_management',
@@ -102,5 +116,7 @@ class servicenow_reporting_integration::incident_management (
     include_facts                           => $include_facts,
     facts_format                            => $facts_format,
     skip_certificate_validation             => $skip_certificate_validation,
+    http_read_timeout                       => $http_read_timeout,
+    http_write_timeout                      => $http_write_timeout,
   }
 }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -16,6 +16,8 @@ class servicenow_reporting_integration (
   Optional[Array[String[1]]] $include_facts                                                               = ['identity.user', 'ipaddress','memorysize', 'memoryfree', 'os'],
   Enum['yaml', 'pretty_json', 'json'] $facts_format                                                       = 'pretty_json',
   Optional[Boolean] $skip_certificate_validation                                                          = false,
+  Optional[Variant[Integer[0], Float[0]]] $http_read_timeout                                              = 60,
+  Optional[Variant[Integer[0], Float[0]]] $http_write_timeout                                             = 60,
   # PARAMETERS SPECIFIC TO INCIDENT_MANAGEMENT
   Optional[String[1]] $caller_id                                                                          = undef,
   Optional[String[1]] $category                                                                           = undef,
@@ -120,6 +122,8 @@ class servicenow_reporting_integration (
       facts_format                               => $facts_format,
       disabled                                   => $disabled,
       skip_certificate_validation                => $skip_certificate_validation,
+      http_read_timeout                          => $http_read_timeout,
+      http_write_timeout                         => $http_write_timeout,
       }),
     notify       => $settings_file_notify,
   }

--- a/templates/servicenow_reporting.yaml.epp
+++ b/templates/servicenow_reporting.yaml.epp
@@ -24,6 +24,8 @@
       String $facts_format,
       Optional[Boolean] $disabled,
       Optional[Boolean] $skip_certificate_validation,
+      Optional[Integer] $http_read_timeout,
+      Optional[Integer] $http_write_timeout,
       # Extra variables that _aren't_ part of the servicenow_reporting_integration
       # class' parameters go here
       String $report_processor_version,
@@ -56,4 +58,6 @@ include_facts: <%= $include_facts %>
 facts_format: <%= $facts_format %>
 disabled: <%= $disabled %>
 skip_certificate_validation: <%= $skip_certificate_validation %>
+http_read_timeout: <%= $http_read_timeout %>
+http_write_timeout: <%= $http_write_timeout %>
 report_processor_version: <%= $report_processor_version %>


### PR DESCRIPTION
This change adds user parameters to set the HTTP timeout arguments
to the `Net::HTTP.start` method used by the module to make
Servicenow API requests.

The `http_read_timeout` parameter sets the following arguments to the
same value: `ssl_timeout`, `read_timeout`, `connect_timeout`. Most users
will consider these to be functionally the same timeout so there is
little reason at the momen to increase the module's complexity by
exposing each of those arguments as a separate parameter for users.

The `http_write_timeout` parameter sets the `write_timeout` argument.

These parameters are not explicitly acceptance tested because that is
functionally testing the `Net::HTTP` class, which is beyond the scope of
this module. They are unit tested to ensure we don't make any changes
that might accidentaly cause them not to be passed to the underlying
Ruby class.