### PR TITLE
(MAINT) Elevate resource event categories to top level keys

### DIFF
--- a/spec/acceptance/reporting/event_spec.rb
+++ b/spec/acceptance/reporting/event_spec.rb
@@ -43,9 +43,11 @@ describe 'ServiceNow reporting: event management' do
     expect(additional_info['ipaddress']).to match(%r{^(?:[0-9]{1,3}\.){3}[0-9]{1,3}$})
     expect(additional_info['os.distro']['codename']).not_to be_empty
     expect(additional_info['report_labels']).to eql('intentional_changes')
-    expect(additional_info['resource_events'].to_json).to match(%r{corrective_changes})
-    expect(additional_info['resource_events'].to_json).to match(%r{intentional_changes})
-    expect(additional_info['resource_events'].to_json).to match(%r{Notify})
+    expect(additional_info['corrective_changes'].to_json).should_not be_nil
+    expect(additional_info['pending_corrective_changes'].to_json).should_not be_nil
+    expect(additional_info['intentional_changes'].to_json).should_not be_nil
+    expect(additional_info['pending_intentional_changes'].to_json).should_not be_nil
+    expect(additional_info['failures'].to_json).should_not be_nil
     # Check that the PE console URL is included
     expect(event['description']).to match(Regexp.new(Regexp.escape(master.uri)))
   end

--- a/spec/unit/reports/servicenow/event_spec.rb
+++ b/spec/unit/reports/servicenow/event_spec.rb
@@ -34,7 +34,7 @@ describe 'ServiceNow report processor: event_management mode' do
       expect(additional_info['environment']).to eql('production')
       expect(additional_info['ipaddress']).to eql('192.168.0.1')
       expect(additional_info['os.distro']['codename']).to eql('xenial')
-      expect(additional_info['resource_events']['corrective_changes'].first['containment_path']).to eql(['foo', 'bar'])
+      expect(additional_info['corrective_changes'].first['containment_path']).to eql(['foo', 'bar'])
       # The message key will be tested more thoroughly in other
       # tests
       expect(actual_event['message_key']).not_to be_empty


### PR DESCRIPTION
In the additional information event field the resouce events key is
replaced with 5 keys that categorize resources events in to failures,
corrective changes, etc.