### PR TITLE
(PIE-380) Add an event type for corrective changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ To send events, classify your Puppet servers with the `servicenow_reporting_inte
 By default each event will include the following information:
 * __Source__: Puppet
 * __Node__: The node the agent ran on
-* __Type__: The type of event. Can be one of `node_report_changed`, `node_report_unchanged`, `node_report_failed`
+* __Type__: The type of event. Can be one of `node_report_intentional_changes`, `node_report_corrective_changes`, `node_report_unchanged`, `node_report_failed`
 * __Source instance__: The name of the Puppet server that generated the report
 * __Message Key__: A hash of all of the relevant report properties to ensure that future events are grouped together properly
 * __Severity__: The highest severity rating of all of the events that occurred in a given run. These severity levels can be configured via the `<change_type>_event_severity` class parameters, including the severity of `no_changes` reports via the `no_changes_events_severity` parameter.

--- a/lib/puppet/reports/servicenow.rb
+++ b/lib/puppet/reports/servicenow.rb
@@ -22,7 +22,7 @@ Puppet::Reports.register_report(:servicenow) do
   def process_event_management(settings_hash)
     event_data = {
       'source'          => 'Puppet',
-      'type'            => "node_report_#{status}",
+      'type'            => event_type(resource_statuses, status),
       'severity'        => calculate_event_severity(resource_statuses, settings_hash, transaction_completed).to_s,
       'node'            => host,
       # Source Instance is sent as event_class in the api

--- a/lib/puppet/util/servicenow.rb
+++ b/lib/puppet/util/servicenow.rb
@@ -180,6 +180,21 @@ module Puppet::Util::Servicenow
   end
   module_function :calculate_event_conditions
 
+  def event_type(resource_statuses, status)
+    case status
+    when 'unchanged'
+      'node_report_unchanged'
+    when 'failed'
+      'node_report_failed'
+    when 'changed'
+      event_conditions = calculate_event_conditions(resource_statuses)
+      applicable_event_conditions = event_conditions.select { |_, condition| condition == true }.keys
+      return 'node_report_corrective_changes' if applicable_event_conditions.include?('corrective_changes')
+      'node_report_intentional_changes'
+    end
+  end
+  module_function :event_type
+
   def event_security_string(event_security_string)
     security_settings = {
       'Clear' => 0,

--- a/spec/acceptance/reporting/event_spec.rb
+++ b/spec/acceptance/reporting/event_spec.rb
@@ -24,7 +24,7 @@ describe 'ServiceNow reporting: event management' do
     additional_info = JSON.parse(event['additional_info'])
 
     expect(event['source']).to eql('Puppet')
-    expect(event['type']).to eql('node_report_changed')
+    expect(event['type']).to eql('node_report_intentional_changes')
     expect(event['severity']).to eql('5')
     expect(event['message_key']).not_to be_empty
     expect(event['node']).not_to be_empty

--- a/spec/unit/reports/servicenow/event_spec.rb
+++ b/spec/unit/reports/servicenow/event_spec.rb
@@ -19,7 +19,7 @@ describe 'ServiceNow report processor: event_management mode' do
     expect_sent_event(expected_credentials) do |actual_event|
       additional_info = JSON.parse(actual_event['additional_info'])
       expect(actual_event['source']).to eql('Puppet')
-      expect(actual_event['type']).to eql('node_report_changed')
+      expect(actual_event['type']).to eql('node_report_intentional_changes')
       expect(actual_event['severity']).to eql('5')
       expect(actual_event['node']).to eql('fqdn')
       expect(actual_event['description']).to match(%r{test_console})
@@ -50,7 +50,7 @@ describe 'ServiceNow report processor: event_management mode' do
 
     expect_sent_event(expected_credentials) do |actual_event|
       expect(actual_event['source']).to eql('Puppet')
-      expect(actual_event['type']).to eql('node_report_changed')
+      expect(actual_event['type']).to eql('node_report_intentional_changes')
       expect(actual_event['severity']).to eql('5')
       expect(actual_event['node']).to eql('fqdn')
       expect(actual_event['description']).to match(%r{test_console})
@@ -72,14 +72,14 @@ describe 'ServiceNow report processor: event_management mode' do
     end
   end
 
-  it 'sends a node_report_failure' do
-    allow(processor).to receive(:status).and_return 'failure'
+  it 'sends a node_report_failed' do
+    allow(processor).to receive(:status).and_return 'failed'
     allow(processor).to receive(:host).and_return 'fqdn'
     mock_event_as_resource_status(processor, 'failure', false, false)
 
     expect_sent_event(expected_credentials) do |actual_event|
       expect(actual_event['source']).to eql('Puppet')
-      expect(actual_event['type']).to eql('node_report_failure')
+      expect(actual_event['type']).to eql('node_report_failed')
       expect(actual_event['severity']).to eql('3')
       expect(actual_event['node']).to eql('fqdn')
       expect(actual_event['description']).to match(%r{test_console})


### PR DESCRIPTION
Users need to be able to identify whether an event type is a corrective
or intentional change. This change adds another event type that flags
corrective changes and marks all other changes as intentional.