### PR TITLE
(PIE-409) Add change type hash keys

### DIFF
--- a/lib/puppet/util/servicenow.rb
+++ b/lib/puppet/util/servicenow.rb
@@ -143,11 +143,16 @@ module Puppet::Util::Servicenow
         (resource.corrective_change == true) ? (corrective_changes << event_summary) : (intentional_changes << event_summary)
       end
     end
-    { 'corrective_changes'          => corrective_changes,
-      'intentional_changes'         => intentional_changes,
-      'pending_corrective_changes'  => pending_corrective_changes,
-      'pending_intentional_changes' => pending_intentional_changes,
-      'failures'                    => failures }
+    { 'corrective_changes'               => corrective_changes,
+      'corrective_changes_hash'          => corrective_changes.empty? ? [] : Digest::SHA1.hexdigest(corrective_changes.to_json.chars.sort.join),
+      'intentional_changes'              => intentional_changes,
+      'intentional_changes_hash'         => intentional_changes.empty? ? [] : Digest::SHA1.hexdigest(intentional_changes.to_json.chars.sort.join),
+      'pending_corrective_changes'       => pending_corrective_changes,
+      'pending_corrective_changes_hash'  => pending_corrective_changes.empty? ? [] : Digest::SHA1.hexdigest(pending_corrective_changes.to_json.chars.sort.join),
+      'pending_intentional_changes'      => pending_intentional_changes,
+      'pending_intentional_changes_hash' => pending_intentional_changes.empty? ? [] : Digest::SHA1.hexdigest(pending_intentional_changes.to_json.chars.sort.join),
+      'failures'                         => failures,
+      'failures_hash'                    => failures.empty? ? [] : Digest::SHA1.hexdigest(failures.to_json.chars.sort.join) }
   end
   module_function :additional_info_resource_events
 


### PR DESCRIPTION
If a user wants to group events by the resource change events,
Servicenow has a bug where it cannot handle the raw resource data that
we add to the additional info field. Some sort of problem is enountered
and the message key for the alert is not changed to the desired value.

This change adds a SHA1 key for each change type to the additional info
field, so that Servicenow can add that field to the message key instead
of the full change data. This fixes event grouping.