### PR TITLE
(PIE-448) Prevent Trailing Slash in PE Console URL

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -98,7 +98,7 @@ class servicenow_reporting_integration (
     content      => epp('servicenow_reporting_integration/servicenow_reporting.yaml.epp', {
       instance                                   => $instance,
       operation_mode                             => $operation_mode,
-      pe_console_url                             => $final_console_url,
+      pe_console_url                             => regsubst($final_console_url, '\/$', ''),
       caller_id                                  => $caller_id,
       user                                       => $user,
       password                                   => $password,

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'support/classes/shared_contexts'
+require 'support/unit/sensitive'
+
+describe 'servicenow_reporting_integration' do
+  include_context 'common reporting integration setup'
+
+  let(:params) do
+    {
+      'instance'                                => 'foo_instance',
+      'pe_console_url'                          => 'foo_pe_console_url/',
+      'user'                                    => 'foo_user',
+      'password'                                => RSpec::Puppet::Sensitive.new('foo_password'),
+      'operation_mode'                          => 'event_management',
+      'servicenow_credentials_validation_table' => 'em_event',
+    }
+  end
+
+  let(:file_resource_title) do
+    # rspec-puppet tries its best to work with both Windows and Linux, but it
+    # ends up with strange behavior in the $settings::confdir setting such that
+    # it is not consistent when running on Linux and Windows. This function
+    # is here to make sure the tests aren't broken due to the inconsistencies.
+    # "#{Dir.pwd.gsub('\\','/')}/servicenow_reporting.yaml"
+
+    "#{Dir.pwd.tr('\\', '/')}/servicenow_reporting.yaml"
+  end
+
+  it { is_expected.to compile }
+  it { is_expected.to contain_file(file_resource_title).with_content %r{^pe_console_url: foo_pe_console_url$} }
+
+  context 'consule url does not have a trialing slash' do
+    let(:params) do
+      super().merge('pe_console_url' => 'foo_pe_console_url')
+    end
+
+    it { is_expected.to contain_file(file_resource_title).with_content %r{^pe_console_url: foo_pe_console_url$} }
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -50,6 +50,7 @@ RSpec.configure do |c|
   c.filter_run_excluding(bolt: true) unless ENV['GEM_BOLT']
   c.after(:suite) do
   end
+  c.confdir = '.'
 end
 
 # Ensures that a module is defined


### PR DESCRIPTION
When a trailing slash is present in the PE_CONSOLE_URL, some customers
have seen bugs.

This change prevents that setting from being written to the settings
yaml file with a trailing slash.