### PR TITLE
(MAINT) Bump Ruby Version For CI

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -5,7 +5,7 @@ pipeline{
         label 'worker'
     }
     environment {
-      RUBY_VERSION='2.5.1'
+      RUBY_VERSION='2.5.7'
       GEM_SOURCE='https://artifactory.delivery.puppetlabs.net/artifactory/api/gems/rubygems/'
       RAKE_SETUP_TASK='rake acceptance:setup'
       RAKE_TEST_TASK='rake acceptance:run_tests'


### PR DESCRIPTION
CI has started to fail because the ruby version in use prior to this
change causes gem dependency conflicts in the Gemfile. Bumping the ruby
version resolves the conflicts.