### PR TITLE
(MAINT) Fix CI Errors

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -5,7 +5,7 @@ pipeline{
         label 'worker'
     }
     environment {
-      RUBY_VERSION='2.5.1'
+      RUBY_VERSION='2.5.7'
       GEM_SOURCE='https://artifactory.delivery.puppetlabs.net/artifactory/api/gems/rubygems/'
       RAKE_SETUP_TASK='rake acceptance:setup'
       RAKE_TEST_TASK='rake acceptance:run_tests'

--- a/spec/support/acceptance/servicenow/Dockerfile
+++ b/spec/support/acceptance/servicenow/Dockerfile
@@ -1,7 +1,7 @@
 # Unfortunately, building from 2.5 leads to https://github.com/debauchee/barrier/issues/126
 # which means that we can't curl our mock instance. Thus, we build this from 2.5-alpine
 # instead.
-FROM ruby:2.5-alpine
+FROM artifactory.delivery.puppetlabs.net/ruby:2.5-alpine
 
 WORKDIR .
 


### PR DESCRIPTION
CI has started to fail because the ruby version in use prior to this
change causes gem dependency conflicts in the Gemfile. Bumping the ruby
version resolves the conflicts.

It is also failing because we have hit the docker cloud rate limit. The
ruby image we use to build the mocking container is been uploaded to
artifactory and we also switch to pulling from artifactory to avoid the
rate limit.