### PR TITLE
Adding the host name to incident_data

### DIFF
--- a/lib/puppet/reports/servicenow.rb
+++ b/lib/puppet/reports/servicenow.rb
@@ -96,6 +96,7 @@ Puppet::Reports.register_report(:servicenow) do
       urgency: settings_hash['urgency'],
       assignment_group: settings_hash['assignment_group'],
       assigned_to: settings_hash['assigned_to'],
+      cmdb_ci: host,
     }
 
     endpoint = "#{instance_with_protocol(settings_hash['instance'])}/api/now/table/incident"


### PR DESCRIPTION
Added the host parameter to the incident_data with the name cmdb_ci.
When an incident is created, if the host name exists in ServiceNow it is added to the Configuration item field, if the host name doesn't exist in ServiceNow the field is left blank.