### PR TITLE
(PIE-522) Add Report Filter for Events

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ To stop the module from sending any events to Servicenow, you can set the `disab
 
 ### Incidents
 
-To send incidents, classify your Puppet server nodes with the `servicenow_reporting_integration::incident_mangement` class. The minimum parameters you need to configure for the class to work are `instance` (the fqdn of the Servicenow instance), and then `user` and `password`, or you can bypass username/password authentication and use an oauth token using the `oauth_token` parameter. Lastly you will need to get the `sys_id` of the user you would like to use as the 'Caller' for each ticket. The `servicenow_reporting_integration::incident_management` class requires the `sys_id` for a user to be placed in the the `caller_id` parameter because that is a required incident field on ServiceNow’s end. Look below for steps to get the `sys_id` for a user from Servicenow. 
+To send incidents, classify your Puppet server nodes with the `servicenow_reporting_integration::incident_mangement` class. The minimum parameters you need to configure for the class to work are `instance` (the fqdn of the Servicenow instance), and then `user` and `password`, or you can bypass username/password authentication and use an oauth token using the `oauth_token` parameter. Lastly you will need to get the `sys_id` of the user you would like to use as the 'Caller' for each ticket. The `servicenow_reporting_integration::incident_management` class requires the `sys_id` for a user to be placed in the the `caller_id` parameter because that is a required incident field on ServiceNow’s end. Look below for steps to get the `sys_id` for a user from Servicenow.
 
 To get the desired `sys_id` from Servicenow:
 1. In the Application Navigator (left sidebar navigation menu) navigate to System Security > Users and Groups > Users
@@ -133,7 +133,7 @@ For example...
 ```
 export SN_INSTANCE=dev84270.service-now.com
 export SN_PASSWORD='d0hPFGhj5iNU!!!'
-export SN_USER=admin  
+export SN_USER=admin
 ```
 
 To run the tests after setup, you can do `bundle exec rspec spec/acceptance`. To teardown the infrastructure, do `bundle exec rake acceptance:tear_down`.

--- a/Rakefile
+++ b/Rakefile
@@ -229,7 +229,7 @@ namespace :acceptance do
   task :ci_run_tests do
     begin
       Rake::Task['acceptance:setup'].invoke
-      Rake::Task['acceptance:run_tests'].invoke 
+      Rake::Task['acceptance:run_tests'].invoke
     ensure
       Rake::Task['acceptance:tear_down'].invoke
     end

--- a/manifests/event_management.pp
+++ b/manifests/event_management.pp
@@ -82,6 +82,8 @@ class servicenow_reporting_integration::event_management (
   Optional[Variant[Integer[0], Float[0]]] $http_read_timeout                                              = 60,
   Optional[Variant[Integer[0], Float[0]]] $http_write_timeout                                             = 60,
   Enum['selfsigned', 'truststore', 'none'] $pe_console_cert_validation                                    = 'selfsigned',
+  Servicenow_reporting_integration::ReportCategories $event_creation_conditions                           = ['always'],
+
 ) {
   class { 'servicenow_reporting_integration':
     operation_mode                             => 'event_management',
@@ -104,5 +106,6 @@ class servicenow_reporting_integration::event_management (
     http_read_timeout                          => $http_read_timeout,
     http_write_timeout                         => $http_write_timeout,
     pe_console_cert_validation                 => $pe_console_cert_validation,
+    event_creation_conditions                  => $event_creation_conditions,
   }
 }

--- a/manifests/incident_management.pp
+++ b/manifests/incident_management.pp
@@ -94,7 +94,7 @@ class servicenow_reporting_integration::incident_management (
   Optional[Integer] $urgency                                                                 = undef,
   Optional[String[1]] $assignment_group                                                      = undef,
   Optional[String[1]] $assigned_to                                                           = undef,
-  Servicenow_reporting_integration::IncidentCreationConditions $incident_creation_conditions = ['failures', 'corrective_changes'],
+  Servicenow_reporting_integration::ReportCategories $incident_creation_conditions           = ['failures', 'corrective_changes'],
   String $servicenow_credentials_validation_table                                            = 'incident',
   Optional[Array[String[1]]] $include_facts                                                  = ['aio_agent_version', 'id', 'memorysize', 'memoryfree', 'ipaddress', 'ipaddress6', 'os.distro', 'os.windows', 'path', 'uptime', 'rubyversion'],
   Enum['yaml', 'pretty_json', 'json'] $facts_format                                          = 'yaml',

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -1,7 +1,7 @@
 # @summary
 #   This class contains the common setup code for servicenow_reporting_integration::incident_management
 #   and servicenow_reporting_integration::event_management.
-# 
+#
 # @api private
 class servicenow_reporting_integration (
   # OPERATION MODE
@@ -29,7 +29,7 @@ class servicenow_reporting_integration (
   Optional[Integer] $urgency                                                                              = undef,
   Optional[String[1]] $assignment_group                                                                   = undef,
   Optional[String[1]] $assigned_to                                                                        = undef,
-  Optional[Servicenow_reporting_integration::IncidentCreationConditions] $incident_creation_conditions    = undef,
+  Optional[Servicenow_reporting_integration::ReportCategories] $incident_creation_conditions              = undef,
   # PARAMETERS SPECIFIC TO EVENT_MANAGEMENT
   Optional[Servicenow_reporting_integration::Severity_levels] $failures_event_severity                    = undef,
   Optional[Servicenow_reporting_integration::Severity_levels] $corrective_changes_event_severity          = undef,
@@ -38,6 +38,8 @@ class servicenow_reporting_integration (
   Optional[Servicenow_reporting_integration::Severity_levels] $pending_intentional_changes_event_severity = undef,
   Optional[Servicenow_reporting_integration::Severity_levels] $no_changes_event_severity                  = undef,
   Optional[Boolean] $disabled                                                                             = false,
+  Optional[Servicenow_reporting_integration::ReportCategories] $event_creation_conditions                 = undef,
+
 ) {
   if (($user or $password) and $oauth_token) {
     fail('please specify either user/password or oauth_token not both.')
@@ -111,7 +113,7 @@ class servicenow_reporting_integration (
       urgency                                    => $urgency,
       assignment_group                           => $assignment_group,
       assigned_to                                => $assigned_to,
-      incident_creation_conditions               => $incident_creation_conditions ,
+      incident_creation_conditions               => $incident_creation_conditions,
       report_processor_version                   => $report_processor_version,
       failures_event_severity                    => $failures_event_severity,
       corrective_changes_event_severity          => $corrective_changes_event_severity,
@@ -126,6 +128,7 @@ class servicenow_reporting_integration (
       http_read_timeout                          => $http_read_timeout,
       http_write_timeout                         => $http_write_timeout,
       pe_console_cert_validation                 => $pe_console_cert_validation,
+      event_creation_conditions                  => $event_creation_conditions,
       }),
     notify       => $settings_file_notify,
   }

--- a/spec/support/unit/reports/servicenow_spec_helpers.rb
+++ b/spec/support/unit/reports/servicenow_spec_helpers.rb
@@ -48,6 +48,7 @@ def default_settings_hash
     'skip_certificate_validation'                => true,
     'http_read_timeout'                          => 60,
     'http_write_timeout'                         => 60,
+    'event_creation_conditions'                  => ['always'],
   }
 end
 

--- a/templates/servicenow_reporting.yaml.epp
+++ b/templates/servicenow_reporting.yaml.epp
@@ -27,6 +27,7 @@
       Optional[Integer] $http_read_timeout,
       Optional[Integer] $http_write_timeout,
       Enum['selfsigned', 'truststore', 'none'] $pe_console_cert_validation,
+      Optional[Array[String]] $event_creation_conditions,
       # Extra variables that _aren't_ part of the servicenow_reporting_integration
       # class' parameters go here
       String $report_processor_version,
@@ -63,3 +64,4 @@ http_read_timeout: <%= $http_read_timeout %>
 http_write_timeout: <%= $http_write_timeout %>
 pe_console_cert_validation: <%= $pe_console_cert_validation %>
 report_processor_version: <%= $report_processor_version %>
+event_creation_conditions: <%= $event_creation_conditions %>

--- a/types/reportcategories.pp
+++ b/types/reportcategories.pp
@@ -15,7 +15,7 @@
 #   'pending_intentional_changes'
 #       Create an incident if the report contains at least one intentional change
 #       that wasn't applied because of noop
-type Servicenow_reporting_integration::IncidentCreationConditions = Array[Enum[
+type Servicenow_reporting_integration::ReportCategories = Array[Enum[
   'always',
   'never',
   'failures',


### PR DESCRIPTION
Re-implemented report filtering from incidents reporting to work for
events reporting. Can choose the type of report being sent by specifying
report categories in init.pp.
Added unit and acceptance tests for the report filter in events reporting.

------
Thanks for your contribution! Note that all community contributors will be required to sign our Contributor License Agreement, unless you fall under the [Trivial Patch Exemption Policy](https://puppet.com/community/trivial-patch-exemption-policy). If you believe it applies to your pull request, please comment explaining why you do not need to sign the CLA. Directions for signing will be attached to your pull request shortly.

Please note that all contributions may be publicly recognized in release notes.
