### PR TITLE
PIE-523 Add Environment filter

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ The ServiceNow reporting integration module ships with a `servicenow` report pro
 2. [Setup](#setup)
     * [Events](#events)
     * [Incidents](#incidents)
+    * [Filtering](#filtering)
 3. [Troubleshooting](#troubleshooting)
 4. [Development](#development)
 5. [Known Issues](#known-issues)
@@ -89,6 +90,10 @@ Each incident will include the following information provided by Puppet:
   * __Node__: the fqdn of the node the agent ran on
   * __Report Time__: The timestamp of the report to help find the report in the console
 * __Description__: See the description section from event management above. Incidents will get the same description
+
+### Filtering
+
+For both incidents and events, you can filter sending reports on the environment using an allow_list and block_list. You can set these lists in the module's parameters. The allow_list is defaulted to ['all'] and the block_list is defaulted to ['none']. If you have specific environment filters, you can add them to the list. You can also use wildcards (ie. \*filter\*).
 
 ## Troubleshooting
 

--- a/lib/puppet/reports/servicenow.rb
+++ b/lib/puppet/reports/servicenow.rb
@@ -29,8 +29,9 @@ Puppet::Reports.register_report(:servicenow) do
     Puppet.info(sn_log_entry("event creation conditions: #{event_creation_conditions}"))
 
     satisfied_conditions = calculate_satisfied_conditions(status, resource_statuses, event_creation_conditions, transaction_completed)
+    exists_in_blocked_list = env_filter_not_allowed?(environment, settings['allow_list'], settings['block_list'])
 
-    if satisfied_conditions.empty?
+    if satisfied_conditions.empty? || exists_in_blocked_list
       Puppet.info(sn_log_entry('decision: Do not create event'))
       # do not create an event
       return false
@@ -92,8 +93,9 @@ Puppet::Reports.register_report(:servicenow) do
     Puppet.info(sn_log_entry("incident creation conditions: #{incident_creation_conditions}"))
 
     satisfied_conditions = calculate_satisfied_conditions(status, resource_statuses, incident_creation_conditions, transaction_completed)
+    exists_in_blocked_list = env_filter_not_allowed?(environment, settings['allow_list'], settings['block_list'])
 
-    if satisfied_conditions.empty?
+    if satisfied_conditions.empty? || exists_in_blocked_list
       Puppet.info(sn_log_entry('decision: Do not create incident'))
       # do not create an incident
       return false

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -19,6 +19,8 @@ class servicenow_reporting_integration (
   Optional[Variant[Integer[0], Float[0]]] $http_read_timeout                                              = 60,
   Optional[Variant[Integer[0], Float[0]]] $http_write_timeout                                             = 60,
   Enum['selfsigned', 'truststore', 'none'] $pe_console_cert_validation                                    = 'selfsigned',
+  Optional[Array[String[1]]] $allow_list                                                                  = ['all'],
+  Optional[Array[String[1]]] $block_list                                                                  = ['none'],
   # PARAMETERS SPECIFIC TO INCIDENT_MANAGEMENT
   Optional[String[1]] $caller_id                                                                          = undef,
   Optional[String[1]] $category                                                                           = undef,
@@ -129,6 +131,8 @@ class servicenow_reporting_integration (
       http_write_timeout                         => $http_write_timeout,
       pe_console_cert_validation                 => $pe_console_cert_validation,
       event_creation_conditions                  => $event_creation_conditions,
+      allow_list                                 => $allow_list,
+      block_list                                 => $block_list,
       }),
     notify       => $settings_file_notify,
   }

--- a/spec/support/unit/reports/servicenow_spec_helpers.rb
+++ b/spec/support/unit/reports/servicenow_spec_helpers.rb
@@ -49,6 +49,8 @@ def default_settings_hash
     'http_read_timeout'                          => 60,
     'http_write_timeout'                         => 60,
     'event_creation_conditions'                  => ['always'],
+    'allow_list'                                 => ['all'],
+    'block_list'                                 => ['none'],
   }
 end
 

--- a/spec/unit/reports/servicenow/misc_spec.rb
+++ b/spec/unit/reports/servicenow/misc_spec.rb
@@ -120,4 +120,23 @@ describe 'ServiceNow report processor: miscellaneous tests' do
       end
     end
   end
+
+  context 'filters environment via allow and block lists' do
+    [
+      { environment: 'production', allow_list: ['all'], block_list: ['test'], expected_value: false },
+      { environment: 'production', allow_list: ['none'], block_list: ['test'], expected_value: true },
+      { environment: 'production', allow_list: ['production'], block_list: ['test'], expected_value: false },
+      { environment: '1.0-release-2', allow_list: ['*release*'], block_list: ['test'], expected_value: false },
+      { environment: 'production', allow_list: ['release'], block_list: ['all'], expected_value: true },
+      { environment: 'production', allow_list: ['production'], block_list: ['none'], expected_value: false },
+      { environment: 'production', allow_list: ['release'], block_list: ['production'], expected_value: true },
+      { environment: 'release-2', allow_list: ['production'], block_list: ['release*'], expected_value: true },
+      { environment: '1.0-release', allow_list: ['*release'], block_list: ['*release'], expected_value: true },
+      { environment: '1.0-prod-4', allow_list: ['none'], block_list: ['none'], expected_value: true },
+    ].each do |test_case|
+      it "When environment is #{test_case[:environment]}, and allow_list is set to #{test_case[:allow_list]} and block_list is set to #{test_case[:block_list]}, expect to return #{test_case[:expected_value]}" do
+        expect(Puppet::Util::Servicenow.env_filter_not_allowed?(test_case[:environment], test_case[:allow_list], test_case[:block_list])).to be test_case[:expected_value]
+      end
+    end
+  end
 end

--- a/templates/servicenow_reporting.yaml.epp
+++ b/templates/servicenow_reporting.yaml.epp
@@ -28,6 +28,8 @@
       Optional[Integer] $http_write_timeout,
       Enum['selfsigned', 'truststore', 'none'] $pe_console_cert_validation,
       Optional[Array[String]] $event_creation_conditions,
+      Optional[Array[String]] $allow_list,
+      Optional[Array[String]] $block_list,
       # Extra variables that _aren't_ part of the servicenow_reporting_integration
       # class' parameters go here
       String $report_processor_version,
@@ -65,3 +67,5 @@ http_write_timeout: <%= $http_write_timeout %>
 pe_console_cert_validation: <%= $pe_console_cert_validation %>
 report_processor_version: <%= $report_processor_version %>
 event_creation_conditions: <%= $event_creation_conditions %>
+allow_list: <%= $allow_list %>
+block_list: <%= $block_list %>


### PR DESCRIPTION
Created two new parameters 'allow_list' and 'block_list' and a helper
function in util/servicenow.rb that allows users to now specify an
environment other than production.
User can filter on what environment they want to send an event to
ServiceNow by specifying an allow list and block list of environment
names.

Added unit tests for the different list-setting scenarios.