### PR TITLE
PIE-611 Fix Broken Jenkins Tests

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -16,5 +16,7 @@ fixtures:
       "repo": "https://github.com/puppetlabs/puppetlabs-translate"
     facts: 'git://github.com/puppetlabs/puppetlabs-facts.git'
     puppet_agent: 'git://github.com/puppetlabs/puppetlabs-puppet_agent.git'
-    provision: 'git://github.com/puppetlabs/provision.git'
+    provision:
+      repo: "git://github.com/puppetlabs/provision.git"
+      ref: "1ddac67b8a6f829c545103185c05291a47e0776e"
     servicenow_tasks: 'git://github.com/puppetlabs/servicenow_tasks.git'

--- a/Gemfile
+++ b/Gemfile
@@ -24,13 +24,17 @@ group :development do
   gem "json", '= 2.0.4',                                         require: false if Gem::Requirement.create('~> 2.4.2').satisfied_by?(Gem::Version.new(RUBY_VERSION.dup))
   gem "json", '= 2.1.0',                                         require: false if Gem::Requirement.create(['>= 2.5.0', '< 2.7.0']).satisfied_by?(Gem::Version.new(RUBY_VERSION.dup))
   gem "rb-readline", '= 0.5.5',                                  require: false, platforms: [:mswin, :mingw, :x64_mingw]
-  gem "puppet_litmus", '~> 0.18',                                require: false, platforms: [:ruby]
+  # Temporarily setting puppet_litmus version to 0.26.0 or older because new litmus version changes where the inventory file gets
+  # created/the name changes to litmus_inventory.yml which is not compatible with the current tests.
+  gem "puppet_litmus", '~> 0.18', '<= 0.26.0',                    require: false, platforms: [:ruby]
   gem "puppet-module-posix-default-r#{minor_version}", '~> 0.4', require: false, platforms: [:ruby]
   gem "puppet-module-posix-dev-r#{minor_version}", '~> 0.4',     require: false, platforms: [:ruby]
   gem "puppet-module-win-default-r#{minor_version}", '~> 0.4',   require: false, platforms: [:mswin, :mingw, :x64_mingw]
   gem "puppet-module-win-dev-r#{minor_version}", '~> 0.4',       require: false, platforms: [:mswin, :mingw, :x64_mingw]
   gem "rspec_junit_formatter",                                   require: false
 end
+
+
 
 puppet_version = ENV['PUPPET_GEM_VERSION']
 facter_version = ENV['FACTER_GEM_VERSION']


### PR DESCRIPTION
There are some discrepancies between some of the module versions in use
and the reporting_integration module. This current workaround pins the
versions of the provision module and puppet_litmus that work with the
reporting_integration.

Provision module is set to a specific SHA.
Puppet_litmus is set to version 0.26.0 or earlier (lowerbound of 0.18).