### PR TITLE
(PIE-633) Include Hostname

### DIFF
--- a/lib/puppet/reports/servicenow.rb
+++ b/lib/puppet/reports/servicenow.rb
@@ -114,6 +114,7 @@ Puppet::Reports.register_report(:servicenow) do
       urgency: settings_hash['urgency'],
       assignment_group: settings_hash['assignment_group'],
       assigned_to: settings_hash['assigned_to'],
+      cmdb_ci: host,
     }
 
     endpoint = "#{instance_with_protocol(settings_hash['instance'])}/api/now/table/incident"


### PR DESCRIPTION
Added 'cmdb_ci: host,' to lib/puppet/reports/servicenow.rb to include the host fact in the data that gets sent.