### PR TITLE
PIE-651 Publish to Forge Prep

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,7 +35,8 @@ jobs:
 
     - name: Publish module to the forge
       env:
-        BLACKSMITH_FORGE_TOKEN: ${{ secrets.FORGE_API_KEY }}
+        BLACKSMITH_FORGE_USERNAME: {{ secrets.FORGE_USERNAME }}
+        BLACKSMITH_FORGE_PASSWORD: {{ secrets.FORGE_PASSWORD }}
       run: | 
         bundle install --with release
         bundle exec rake module:build

--- a/.github/workflows/release_prep.yml
+++ b/.github/workflows/release_prep.yml
@@ -11,12 +11,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Extract branch name
-      run: echo ::set-env name=GITHUB_BRANCH::$(echo ${GITHUB_REF#refs/heads/})
+      run: echo "GITHUB_BRANCH=$(echo ${GITHUB_REF#refs/heads/})" >> $GITHUB_ENV
 
     - name: Set up Ruby
       uses: ruby/setup-ruby@v1
       with:
-        ruby-version: 2.5.3
+        ruby-version: 2.5.7
 
     - name: Update Rubygems
       run: gem update --system 3.1.0
@@ -38,10 +38,10 @@ jobs:
 
     - name: Calculate the release prep commit's COMMIT_TITLE, COMMIT_BODY_MAIN, COMMIT_BODY_NOTE
       run: |
-        echo ::set-env name=COMMIT_TITLE::$(echo 'Release prep to ${{ github.event.inputs.module_version }}')
-        echo ::set-env name=COMMIT_BODY_MAIN::$(echo -n 'You will need to manually update the \`CHANGELOG.md\` file. First, checkout this PR on your local machine via something like \`git fetch upstream; git checkout upstream/release_prep\`. Then, once you have updated the \`CHANGELOG.md\` file, \`git commit --amend\` your update, then push your changes to this PR via something like \`git push --set-upstream upstream.\`')
+        echo "COMMIT_TITLE=$(echo 'Release prep to ${{ github.event.inputs.module_version }}')" >> $GITHUB_ENV
+        echo "COMMIT_BODY_MAIN=$(echo -n 'You will need to manually update the \`CHANGELOG.md\` file. First, checkout this PR on your local machine via something like \`git fetch upstream; git checkout upstream/release_prep\`. Then, once you have updated the \`CHANGELOG.md\` file, \`git commit --amend\` your update, then push your changes to this PR via something like \`git push --set-upstream upstream.\`')" >> $GITHUB_ENV
         if [ ! -z '${{ steps.most_recent_tag.outputs.tag  }}' ]; then
-          echo ::set-env name=COMMIT_BODY_NOTE::$(echo -n "${commit_body} **Note:** You can use https://github.com/${{ github.repository }}/compare/${{ steps.most_recent_tag.outputs.tag  }}...${{ env.GITHUB_BRANCH }} to see all the new commits that have landed since the previous release.")
+          echo "COMMIT_BODY_NOTE=$(echo -n "${commit_body} **Note:** You can use https://github.com/${{ github.repository }}/compare/${{ steps.most_recent_tag.outputs.tag  }}...${{ env.GITHUB_BRANCH }} to see all the new commits that have landed since the previous release.")" >> $GITHUB_ENV
         fi
 
     - name: Generate the release prep commit

--- a/Gemfile
+++ b/Gemfile
@@ -26,14 +26,14 @@ group :development do
   gem "rb-readline", '= 0.5.5',                                  require: false, platforms: [:mswin, :mingw, :x64_mingw]
   # Temporarily setting puppet_litmus version to 0.26.0 or older because new litmus version changes where the inventory file gets
   # created/the name changes to litmus_inventory.yml which is not compatible with the current tests.
-  gem "puppet_litmus", '~> 0.18', '<= 0.26.0',                    require: false, platforms: [:ruby]
+  gem "puppet_litmus", '~> 0.18', '<= 0.26.0',                   require: false, platforms: [:ruby]
   gem "puppet-module-posix-default-r#{minor_version}", '~> 0.4', require: false, platforms: [:ruby]
   gem "puppet-module-posix-dev-r#{minor_version}", '~> 0.4',     require: false, platforms: [:ruby]
   gem "puppet-module-win-default-r#{minor_version}", '~> 0.4',   require: false, platforms: [:mswin, :mingw, :x64_mingw]
   gem "puppet-module-win-dev-r#{minor_version}", '~> 0.4',       require: false, platforms: [:mswin, :mingw, :x64_mingw]
   gem "rspec_junit_formatter",                                   require: false
+  gem "pdk",                                                     require: false
 end
-
 
 
 puppet_version = ENV['PUPPET_GEM_VERSION']

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "puppetlabs-servicenow_reporting_integration",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "author": "Puppet, Inc.",
   "summary": "A module that allows Puppet to create a ServiceNow incident from an interesting Puppet report",
   "license": "Apache-2.0",


### PR DESCRIPTION
Modify the metadata.json to reflect the new version of the module.
Update the release_prep.yml and release.yml to use new syntax. Instead
of setting the env variables with a : to <<.