### PR TITLE
(PIE-901) Update GitHub deploy actions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,43 +1,26 @@
 name: release
 
 on:
- workflow_dispatch:
+ push:
+  tags:
+    - v[0-9]+.[0-9]+.[0-9]+
 
 jobs:
-  release:
-    runs-on: ubuntu-latest
+  deploy-forge:
+    name: Deploy to Forge
+    runs-on: ubuntu-20.04
     steps:
-    - name: Set up Ruby
-      uses: ruby/setup-ruby@v1
-      with:
-        ruby-version: 2.5.3
+      - name: Checkout code
+        uses: actions/checkout@v2
+        with:
+          ref: ${{ github.ref }}
+          clean: true
+      - name: "PDK Build"
+        uses: docker://puppet/pdk:nightly
+        with:
+          args: 'build'
+      - name: "Push to Forge"
+        uses: docker://puppet/pdk:nightly
+        with:
+          args: 'release publish --forge-token ${{ secrets.FORGE_API_KEY }} --force'
 
-    - name: Update Rubygems
-      run: gem update --system 3.1.0
-
-    - name: Clone repository
-      uses: actions/checkout@v2
-      with:
-        ref: ${{ env.GITHUB_REF }}
-        # Needed to fetch all the tags
-        fetch-depth: 0
-
-    - name: Tag repository
-      run: |
-        module_version=$(cat metadata.json | jq '.version' -r)
-        tag="v${module_version}"
-        if git rev-parse "${tag}" >/dev/null 2>&1; then
-          echo "Module's already been tagged; skipping to the Forge publish step";
-        else
-          git tag ${tag}
-          git push -f --tags
-        fi
-
-    - name: Publish module to the forge
-      env:
-        BLACKSMITH_FORGE_USERNAME: ${{ secrets.FORGE_USERNAME }}
-        BLACKSMITH_FORGE_PASSWORD: ${{ secrets.FORGE_PASSWORD }}
-      run: | 
-        bundle install --with release
-        bundle exec rake module:build
-        bundle exec rake module:push

--- a/.github/workflows/release_prep.yml
+++ b/.github/workflows/release_prep.yml
@@ -4,6 +4,7 @@ on:
   workflow_dispatch:
     inputs:
       module_version:
+        description: 'The new version you would like to release'
         required: true
 
 jobs:
@@ -16,7 +17,7 @@ jobs:
     - name: Set up Ruby
       uses: ruby/setup-ruby@v1
       with:
-        ruby-version: 2.5.7
+        ruby-version: 2.7
 
     - name: Update Rubygems
       run: gem update --system 3.1.0
@@ -44,11 +45,15 @@ jobs:
           echo "COMMIT_BODY_NOTE=$(echo -n "${commit_body} **Note:** You can use https://github.com/${{ github.repository }}/compare/${{ steps.most_recent_tag.outputs.tag  }}...${{ env.GITHUB_BRANCH }} to see all the new commits that have landed since the previous release.")" >> $GITHUB_ENV
         fi
 
+    - name: Release Prep
+      uses: docker://puppet/pdk:nightly
+      with:
+        args: 'release prep --version=${{ github.event.inputs.module_version }} --skip-changelog'
+
     - name: Generate the release prep commit
       run: |
         git checkout -b release_prep
-        bundle install --with release_prep
-        pdk release prep --version=${{ github.event.inputs.module_version }} --skip-changelog
+        bundle install
         git add .
         git -c user.name=${{ github.actor }} -c user.email=${{ github.actor }}@users.noreply.github.com commit -m "${{ env.COMMIT_TITLE }}" -m "${{ env.COMMIT_BODY_MAIN }}" -m '' -m '${{ env.COMMIT_BODY_NOTE }}'
         git push --set-upstream origin release_prep --force
@@ -59,3 +64,4 @@ jobs:
         github_token: ${{ secrets.GITHUB_TOKEN }}
         source_branch: 'release_prep'
         destination_branch: ${{ env.GITHUB_BRANCH }}
+

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,11 +20,13 @@ Each entry should have one of the following formats:
 
 # Releasing the module
 
+# Releasing the module
+
 Run a `release_prep` job with the branch set to `main` and `module_version` set to the module version that will be released
 
 > You can access the `release_prep` job via the `Actions` tab at the repository home page
 
-The `release_prep` job will run the `pdk release prep` command, push its changes up to the `release_prep` branch on the repo, and then generate a PR against `main` for review. Follow the instructions in the PR body to properly update the `CHANGELOG.md` file. Ensure that there is now a heading in the changelog for the new tag, the new heading is a reference link to the diff between the new tag and the previous version tag, that the new heading ends with a - and the date of release in parentheses, and that the __Unreleased__ section is now a reference link to the diff between the new tag and __Head__.
+The `release_prep` job will run the `pdk release prep` command, push its changes up to the `release_prep` branch on the repo, and then generate a PR against `main` for review. Follow the instructions in the PR body to properly update the `CHANGELOG.md` file.
 
 Once the release prep PR's been merged to `main`, run a `release` job with the branch set to `main`. The `release` job will tag the module at the current `metadata.json` version, push the tag upstream, then build and publish the module to the Forge.
 


### PR DESCRIPTION
`Release` and `release prep` actions have been updated for consistency
with our other modules. Deprecated user/password Forge authentication
has been replaced with the appropriate token as a Github secret.
CONTRIBUTING.md has been updated for the changes.