### PR TITLE
(MAINT) GH security move from git to https

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -10,14 +10,11 @@ fixtures:
       repo: "puppetlabs/inifile"
       ref: "1.0.0"
     deploy_pe: 'jarretlavallee/deploy_pe'
+    stdlib: 'puppetlabs/stdlib'
+    puppet_agent: 'puppetlabs/puppet_agent'
+    puppet_conf: 'puppetlabs/puppet_conf'
+    facts: 'puppetlabs/facts'    
   repositories:
-    "stdlib":
-      "repo": "git://github.com/puppetlabs/puppetlabs-stdlib.git"
-    "translate":
-      "repo": "https://github.com/puppetlabs/puppetlabs-translate"
-    facts: 'git://github.com/puppetlabs/puppetlabs-facts.git'
-    puppet_agent: 'git://github.com/puppetlabs/puppetlabs-puppet_agent.git'
-    provision: "git://github.com/puppetlabs/provision.git"
-    servicenow_tasks: 'git://github.com/puppetlabs/servicenow_tasks.git'
-    puppet_conf:
-      repo: 'https://github.com/puppetlabs/puppet_conf.git'
+    translate: 'https://github.com/puppetlabs/puppetlabs-translate'
+    provision: 'https://github.com/puppetlabs/provision'
+    servicenow_tasks: 'https://github.com/puppetlabs/servicenow_tasks.git'


### PR DESCRIPTION
# Summary

Per recent changes to [GH security](https://github.blog/2021-09-01-improving-git-protocol-security-github/), updated repo source protocols in `.fixures.yaml`.

# Detailed Description

  * Updated `.fixtures.yaml` to move public repo sources from `git` to `https` protocol.